### PR TITLE
Update credits for new name WiiStation

### DIFF
--- a/Gamecube/menu/MainFrame.cpp
+++ b/Gamecube/menu/MainFrame.cpp
@@ -172,8 +172,8 @@ void Func_Credits()
 	sprintf(CreditsInfo,"CubeStation Beta 1.0\n");
 #endif
 	strcat(CreditsInfo,"www.github.com/xjsxjs197/WiiSXRX_2022\n");
-	strcat(CreditsInfo,"WiiStation: xjsxjs197\n");
-	strcat(CreditsInfo,"Icon: [author name]\n");
+	strcat(CreditsInfo,"WiiStation: xjsxjs197 - Icon: [author name]\n");
+	strcat(CreditsInfo,"\n");
 	strcat(CreditsInfo,"Original WiiSX team:\n");
 	strcat(CreditsInfo,"emu_kidid - general coding\n");
 	strcat(CreditsInfo,"sepp256 - graphics & menu\n");

--- a/Gamecube/menu/MainFrame.cpp
+++ b/Gamecube/menu/MainFrame.cpp
@@ -167,18 +167,18 @@ void Func_Credits()
 {
 	char CreditsInfo[512] = "";
 #ifdef HW_RVL
-	sprintf(CreditsInfo,"WiiSX RX Beta 2.5\n");
+	sprintf(CreditsInfo,"WiiStation Beta 1.0\n");
 #else
-	sprintf(CreditsInfo,"CubeSX RX Beta 2.5\n");
+	sprintf(CreditsInfo,"CubeStation Beta 1.0\n");
 #endif
-	strcat(CreditsInfo,"www.github.com/niuus/WiiSXRX\n");
-	strcat(CreditsInfo,"WiiSX RX & logo: NiuuS\n");
-	strcat(CreditsInfo,"\n");
+	strcat(CreditsInfo,"www.github.com/xjsxjs197/WiiSXRX_2022\n");
+	strcat(CreditsInfo,"WiiStation: xjsxjs197\n");
+	strcat(CreditsInfo,"Icon: [author name]\n");
 	strcat(CreditsInfo,"Original WiiSX team:\n");
 	strcat(CreditsInfo,"emu_kidid - general coding\n");
 	strcat(CreditsInfo,"sepp256 - graphics & menu\n");
 	strcat(CreditsInfo,"tehpola - audio\n");
-	strcat(CreditsInfo,"PCSX/PCSX-df/PCSX-r teams\n");
+	strcat(CreditsInfo,"PCSX/PCSX-df/PCSX-R/PCSX-ReARMed teams\n");
 	strcat(CreditsInfo,"\n");
 
 	char wiiDetails[30];
@@ -196,10 +196,10 @@ void Func_Credits()
 	sprintf(wiiDetails, "IOS: %d / %s", IOS_GetVersion(), wiiInfo);
 #endif
 #ifdef HW_RVL
-	strcat(CreditsInfo,"FIX94 - Wii U gamepad support\n");
+	strcat(CreditsInfo,"FIX94 - Wii U GamePad support\n");
 	strcat(CreditsInfo,"matguitarist - USB 2.0 support\n");
 	strcat(CreditsInfo,"Daxtsu - libwupc support\n");
-	strcat(CreditsInfo,"Mystro256 - WiiSXR fork\n");
+	strcat(CreditsInfo,"NiuuS - WiiSXRX fork\n");
 	strcat(CreditsInfo,"\n");
 	strcat(CreditsInfo, wiiDetails);
 #endif

--- a/Gamecube/release/apps/WiiSXRX/meta.xml
+++ b/Gamecube/release/apps/WiiSXRX/meta.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
  <app version="2">
-   <name>WiiSXRX</name>
-   <coder>NiuuS</coder>
-   <version>2.5 Beta</version>
-   <release_date>202009081918</release_date>
+   <name>WiiStation</name>
+   <coder>xjsxjs197, NiuuS</coder>
+   <version>1.0 Beta</version>
+   <release_date>20220913</release_date>
    <short_description>PSX Emulator for Wii</short_description>
    <long_description>
+WiiStation - A Sony PlayStation 1 emulator for Wii / Wii U, forked from WiiSXRX by NiuuS.
 Featuring:
 - Gamecube controller support.
 - Wii U Pro controller support.
-- Wii U Gamepad controller support through VC injects.
+- Wii U GamePad controller support through WiiVC injects.
 - Wii Classic Controller and Pro support.
 - Classic Controllers support (NES / SNES)
 
@@ -22,6 +23,8 @@ matguitarist
 Daxtsu
 Mystro256
 FIX94
+NiuuS
+xjsxjs197
    </long_description>
    <ahb_access/>
  </app>


### PR DESCRIPTION
Update credits for match the new name for WiiSXRX_2022, "WiiStation". Also update some credits for this fork's author (xjsxjs197), original WiiSXRX by niuus, etc. Icon credits is in blank because we need a new icon from someone, look at one of these:
1. (made by Dakangel)
![image](https://user-images.githubusercontent.com/66485640/190044604-9b66f2d9-c169-4b74-975a-79b884e648a1.png)
2. (another icon made by Dakangel) 
![image](https://user-images.githubusercontent.com/66485640/190044643-67ef73c5-76df-41f1-a15f-5c845990b41f.png)
3. (made by me, @saulfabregwiivc) 
![image](https://user-images.githubusercontent.com/66485640/190044576-c64375d0-9e0d-4e45-95fd-8f5e1c5464d9.png)
4. (made by tehtemp)
![image](https://user-images.githubusercontent.com/66485640/190044753-9559adf7-7996-48bd-8682-cb97f81f02fe.png)

Please consider one of these icons for the next release of WiiSXRX_2022 as "WiiStation", tell me what icon you like more.
