### PR TITLE
Apply timing and pR3000A autoFixes also when on autoboot mode

### DIFF
--- a/Gamecube/menu/FileBrowserFrame.cpp
+++ b/Gamecube/menu/FileBrowserFrame.cpp
@@ -590,6 +590,11 @@ void fileBrowserFrame_LoadFile(int i)
 
 		if(!ret){	// If the read succeeded.
 			if(Autoboot){
+				// saulfabreg: autoFix function (timing and pR3000a fixes) works but not
+				// in autoboot mode... let's fix this :)
+				CheckGameAutoFix(); // for timing autoFix (Vandal Hearts, Parasite Eve II, etc.)
+				CheckGameR3000AutoFix(); // for pR3000a autoFix (Supercross 2000, etc.)
+				
 				// FIXME: The MessageBox is a hacky way to fix input not responding.
 				// No time to improve this...
 				menu::MessageBox::getInstance().setMessage("Autobooting game...");


### PR DESCRIPTION
Recently i saw that these auto-fixed games (such Vandal Hearts, Parasite Eve 2, Supercross 2000, etc.), work fine on WiiStation thanks to the autoFix functions but these don't work when you're using arguments for enter in autoboot mode. This is specially inconvenient if you like to launch PS1 games on WiiFlow or even from forwarder channels on the Wii System Menu.

This small modification allows the emulator to apply these autoFixes not just when loaded from the emulator menu, but also when using arguments for autoboot PS1 games.

Before autobooting the game, WiiStation first will check if the game ID is selected for have timing auto-fix and/or pR3000A auto-fix, if the game has autoFix then apply them before launching the game.