### PR TITLE
correct some mistakes when adding autoFix for Star Wars: Dark Forces

### DIFF
--- a/Gamecube/menu/FileBrowserFrame.cpp
+++ b/Gamecube/menu/FileBrowserFrame.cpp
@@ -578,13 +578,14 @@ static void CheckGameAutoFix(void)
     }
 
     // For special game correction
-    autoFixLen = 4;
+    autoFixLen = 5;
     char autoFixSpecialGames[autoFixLen][10] = {
         // Star Wars - Dark Forces
-         "SLPS00685" // NTSC-U
+         "SLUS00297" // NTSC-U
+	,"SLPS00685" // NTSC-J
         ,"SLES00585" // PAL
-        ,"SLES00640" // PAL
-        ,"SLES00646" // PAL
+        ,"SLES00640" // PAL (Italy)
+        ,"SLES00646" // PAL (Spain)
     };
     dwActFixes = 0;
     for (i = 0; i < autoFixLen; i++)


### PR DESCRIPTION
@xjsxjs197 

While you were creating this commit https://github.com/xjsxjs197/WiiSXRX_2022/commit/ecd5288aff9678184e959f0579b0e0a066801019, you forgot two things for make this autoFix complete for fix all versions of Star Wars: Dark Forces.
This commit has these small changes:

* added NTSC-U version to this autoFix (SLUS-00297)
* corrected a bit some ID info (such ID SLPS00685 being incorrectly labeled as a NTSC-U / USA version when correct is NTSC-J / Japan)