### PR TITLE
Fix compiling issues related to autoFix info in "Show ISO Info", improve it further

### DIFF
--- a/Gamecube/menu/CurrentRomFrame.cpp
+++ b/Gamecube/menu/CurrentRomFrame.cpp
@@ -178,7 +178,6 @@ void Func_ShowRomInfo()
   	sprintf(buffer, "pR3000 auto fixed\n");
   	strcat(RomInfo,buffer);
   }
-  strcat(RomInfo,buffer);
   sprintf(buffer,"ISO Size: %u Mb\n",isoFile.size/1024/1024);
   strcat(RomInfo,buffer);
   sprintf(buffer,"Country: %s\n",(!Config.PsxType) ? "NTSC":"PAL");

--- a/Gamecube/menu/CurrentRomFrame.cpp
+++ b/Gamecube/menu/CurrentRomFrame.cpp
@@ -42,6 +42,11 @@ extern int SaveMcd(int mcd, fileBrowser_file *savepath);
 extern long ISOgetTN(unsigned char *buffer);
 }
 
+extern int PerGameFix_timing; 		// variable for see if game has timing autoFix
+extern int PerGameFix_GPUbusy; 		// variable for see if game has GPU 'Fake Busy States' (dwEmuFixes) autoFix
+extern int PerGameFix_specialCorrect; 	// variable for see if game has special correction (dwActFixes) autoFix
+extern int PerGameFix_pR3000A; 		// variable for see if game has pR3000A autoFix
+
 void Func_ShowRomInfo();
 void Func_ResetROM();
 void Func_SwapCD();
@@ -153,22 +158,22 @@ void Func_ShowRomInfo()
   sprintf(buffer,"CD-ROM ID: %s\n", CdromId);
 
 	strcat(RomInfo,buffer);
-  if (Config.RCntFix)
+  if (PerGameFix_timing)
   {
   	sprintf(buffer, "RCnt2 auto fixed\n");
   	strcat(RomInfo,buffer);
   }
-  if (dwEmuFixes)
+  if (PerGameFix_GPUbusy)
   {
   	sprintf(buffer, "GPU 'Fake Busy States' hacked\n");
   	strcat(RomInfo,buffer);
   }
-  if (dwActFixes)
+  if (PerGameFix_specialCorrect)
   {
   	sprintf(buffer, "Special game auto fixed\n");
   	strcat(RomInfo,buffer);
   }
-  if (Config.pR3000Fix)
+  if (PerGameFix_pR3000A)
   {
   	sprintf(buffer, "pR3000 auto fixed\n");
   	strcat(RomInfo,buffer);

--- a/Gamecube/menu/CurrentRomFrame.cpp
+++ b/Gamecube/menu/CurrentRomFrame.cpp
@@ -183,7 +183,7 @@ void Func_ShowRomInfo()
   strcat(RomInfo,buffer);
   sprintf(buffer,"Country: %s\n",(!Config.PsxType) ? "NTSC":"PAL");
   strcat(RomInfo,buffer);
-  sprintf(buffer,"BIOS: %s\n",(Config.HLE==BIOS_USER_DEFINED) ? "USER DEFINED":"HLE");
+  sprintf(buffer,"BIOS: %s\n",(Config.HLE==BIOS_USER_DEFINED) ? "PSX":"HLE");
   strcat(RomInfo,buffer);
   unsigned char tracks[2];
   ISOgetTN(&tracks[0]);

--- a/Gamecube/menu/FileBrowserFrame.cpp
+++ b/Gamecube/menu/FileBrowserFrame.cpp
@@ -43,6 +43,11 @@ extern char debugInfo[256];
 
 extern "C" char * JoinString(char *s1, char *s2);
 
+int PerGameFix_timing; 		// variable for see if game has timing autoFix
+int PerGameFix_GPUbusy; 	// variable for see if game has GPU 'Fake Busy States' (dwEmuFixes) autoFix
+int PerGameFix_specialCorrect; 	// variable for see if game has special correction (dwActFixes) autoFix
+int PerGameFix_pR3000A; 	// variable for see if game has pR3000A autoFix
+
 void Func_PrevPage();
 void Func_NextPage();
 void Func_ReturnFromFileBrowserFrame();
@@ -528,13 +533,15 @@ static void CheckGameAutoFix(void)
         ,"SLPS02780" // PARASITE EVE II [SQUARESOFT MILLENNIUM COLLECTION]  -  [ 2 DISCS ]
 
     };
-
+ 
     Config.RCntFix = 0;
+    PerGameFix_timing = 0;
     int i;
     for (i = 0; i < autoFixLen; i++)
     {
         if (ChkString(CdromId, autoFixGames[i], strlen(autoFixGames[i]))) {
             Config.RCntFix = 1;
+	    PerGameFix_timing = 1;
         }
     }
 
@@ -570,10 +577,12 @@ static void CheckGameAutoFix(void)
 
     // hack for emulating "gpu busy" in some games
     dwEmuFixes = 0;
+    PerGameFix_GPUbusy = 0;
     for (i = 0; i < autoFixLen; i++)
     {
         if (ChkString(CdromId, gpuBusyAutoFixGames[i], strlen(gpuBusyAutoFixGames[i]))) {
             dwEmuFixes = 0x0001;
+	    PerGameFix_GPUbusy = 1;
         }
     }
 
@@ -588,10 +597,12 @@ static void CheckGameAutoFix(void)
         ,"SLES00646" // PAL (Spain)
     };
     dwActFixes = 0;
+    PerGameFix_specialCorrect = 0;
     for (i = 0; i < autoFixLen; i++)
     {
         if (ChkString(CdromId, autoFixSpecialGames[i], strlen(autoFixSpecialGames[i]))) {
             dwActFixes |= 0x100;
+	    PerGameFix_specialCorrect = 1;
         }
     }
 }
@@ -612,11 +623,13 @@ static void CheckGameR3000AutoFix(void)
     };
 
     Config.pR3000Fix = 0;
+    PerGameFix_pR3000A = 0;
     int i;
     for (i = 0; i < autoFixR3000Len; i++)
     {
         if (ChkString(CdromId, autoFixR3000JR[i], strlen(autoFixR3000JR[i]))) {
             Config.pR3000Fix = 1;
+	    PerGameFix_pR3000A = 1;
             break;
         }
     }
@@ -630,6 +643,7 @@ static void CheckGameR3000AutoFix(void)
     {
         if (ChkString(CdromId, autoFixR3000LW[i], strlen(autoFixR3000LW[i]))) {
             Config.pR3000Fix = 2;
+	    PerGameFix_pR3000A = 1;
             break;
         }
     }
@@ -644,6 +658,7 @@ static void CheckGameR3000AutoFix(void)
     {
         if (ChkString(CdromId, autoFixR3000SRA[i], strlen(autoFixR3000SRA[i]))) {
             Config.pR3000Fix = 3;
+	    PerGameFix_pR3000A = 1;
             break;
         }
     }


### PR DESCRIPTION
While i was making the PR https://github.com/xjsxjs197/WiiSXRX_2022/pull/64, i didn't had the time for compile it.
Today i attempted to compile it until commit https://github.com/xjsxjs197/WiiSXRX_2022/commit/b101599c1059826678996dca14aa12635ce08c08, but the compiler throw me an error of a variable is not declared.
What i did is add new variables to FileBrowserFrame.cpp, use them, and also then call to use them on CurrentRomFrame.cpp, for detect correctly if the game has autoFixes or not.
This PR, unlike the previous one, was properly tested and working as expected.