### PR TITLE
Add Wii Message Board support for write playlog when loaded from Wii forwarder channels

### DIFF
--- a/Gamecube/WMBPlaylog.c
+++ b/Gamecube/WMBPlaylog.c
@@ -1,0 +1,91 @@
+/*
+	WMBPlaylog.c
+	This code allows to modify play_rec.dat in order to store the
+	game time in Wii's log correctly.
+
+	by Marc
+	Thanks to tueidj for giving me some hints on how to do it :)
+	Most of the code was taken from here:
+	http://forum.wiibrew.org/read.php?27,22130
+
+	Modified by Dimok and SuSo
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <ogcsys.h>
+#include <malloc.h>
+
+#define ALIGN32(x) (((x) + 31) & ~31)
+
+#define SECONDS_TO_2000 946684800LL
+#define TICKS_PER_SECOND 60750000LL
+
+//! Should be 32 byte aligned
+static const char PLAYRECPATH[] ATTRIBUTE_ALIGN(32) = "/title/00000001/00000002/data/play_rec.dat";
+
+typedef struct _PlayRec
+{
+	u32 checksum;
+	union
+	{
+		u32 data[31];
+		struct
+		{
+			u16 name[42];
+			u64 ticks_boot;
+			u64 ticks_last;
+			char title_id[6];
+			char unknown[18];
+		} ATTRIBUTE_PACKED;
+	};
+} PlayRec;
+
+static u64 getWiiTime(void)
+{
+	time_t uTime = time(NULL);
+	return TICKS_PER_SECOND * (uTime - SECONDS_TO_2000);
+}
+
+int Playlog_Exit(void)
+{
+	s32 res = -1;
+	u32 sum = 0;
+	u8 i;
+
+	//Open play_rec.dat
+	s32 fd = IOS_Open(PLAYRECPATH, IPC_OPEN_RW);
+	if(fd < 0)
+		return fd;
+
+	PlayRec * playrec_buf = memalign(32, ALIGN32(sizeof(PlayRec)));
+	if(!playrec_buf)
+		goto cleanup;
+
+	//Read play_rec.dat
+	if(IOS_Read(fd, playrec_buf, sizeof(PlayRec)) != sizeof(PlayRec))
+		goto cleanup;
+
+	if(IOS_Seek(fd, 0, 0) < 0)
+		goto cleanup;
+
+	// update exit time
+	u64 stime = getWiiTime();
+	playrec_buf->ticks_last = stime;
+	
+	//Calculate and update checksum
+	for(i = 0; i < 31; i++)
+		sum += playrec_buf->data[i];
+
+	playrec_buf->checksum = sum;
+
+	if(IOS_Write(fd, playrec_buf, sizeof(PlayRec)) != sizeof(PlayRec))
+		goto cleanup;
+
+	res = 0;
+
+cleanup:
+	free(playrec_buf);
+	IOS_Close(fd);
+	return res;
+}

--- a/Gamecube/WMBPlaylog.h
+++ b/Gamecube/WMBPlaylog.h
@@ -1,0 +1,16 @@
+#ifndef WMBPLAYLOG_H_
+#define WMBPLAYLOG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <gctypes.h>
+
+int Playlog_Exit(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Gamecube/libgui/Gui.cpp
+++ b/Gamecube/libgui/Gui.cpp
@@ -29,6 +29,7 @@
 
 extern "C" {
 #include "../gc_input/controller.h"
+#include "../WMBPlaylog.h"
 #ifdef WII
 #include <di/di.h>
 #endif 
@@ -134,8 +135,9 @@ void Gui::draw()
 				if(*(volatile unsigned int*)0x80001804 == HBC_STUB &&
 					*(volatile unsigned int*)0x80001808 == HBC_HAXX)
 					rld();
-				else
-					SYS_ResetSystem(SYS_RETURNTOMENU, 0, 0);
+				else // Wii channel support
+					Playlog_Exit(); // write playlog (play time) to the Wii Message Board
+					SYS_ResetSystem(SYS_RETURNTOMENU, 0, 0); // Return to the Wii System Menu
 #endif
 			}
 		}


### PR DESCRIPTION
This small but cool modification adds a tested support for handle the Wii Message Board when using WiiStation from Wii forwarder channels (this also applies to SRLs).

What it does is after launching the forwarder channel for WiiStation or a PS1 game loading on WiiStation, the timer starts to count, and when you exit WiiStation, the time you have played will be recorded on the Wii Message Board.

Thanks to Marc, tueidj, Dimok and SuSo for writing the code for the Wii playlog support on the WMB.
Also thanks for SuperrSonic for seeing how to apply this to Wii homebrew.