### PR TITLE
Remove compiling the old PPC dynarec on Makefiles since we're compiling Lightrec

### DIFF
--- a/Gamecube/Makefile_Wii
+++ b/Gamecube/Makefile_Wii
@@ -24,7 +24,7 @@ GPU = Soft
 TARGET		:=	WiiSXRX_debug
 BUILD		:=	build_debug
 SOURCES		:=	../lang ../fonts \
-                . ./gc_input/ ./libgui/ ./menu/ ./fileBrowser/ .. ../ppc/ ../Peops$(GPU)GPU/ \
+                . ./gc_input/ ./libgui/ ./menu/ ./fileBrowser/ .. ../Peops$(GPU)GPU/ \
 				./libgui/gui2 ../dfsound/ ./vm
 
 DATA		:=	data

--- a/Gamecube/Makefile_Wii_Release
+++ b/Gamecube/Makefile_Wii_Release
@@ -24,7 +24,7 @@ GPU = Soft
 TARGET		:=	WiiSXRX_Release
 BUILD		:=	build_release
 SOURCES		:=	../lang ../fonts \
-                . ./gc_input/ ./libgui/ ./menu/ ./fileBrowser/ .. ../ppc/ ../Peops$(GPU)GPU/ \
+                . ./gc_input/ ./libgui/ ./menu/ ./fileBrowser/ .. ../Peops$(GPU)GPU/ \
 				./libgui/gui2 ../dfsound/ ./vm
 
 DATA		:=	data


### PR DESCRIPTION
This simple modification on the Makefiles remove the need of compiling the old PPC dynarec, since we're using now Lightrec and not the old PPC dynarec.

At line 27 of both Wii makefiles (debug and release) you forgot to remove the ../ppc/ string.
Remember that in this "Lightrec" branch we are adding Lightrec for replace the old PPC dynarec, so this should be removed in order for avoid conflict.