### PR TITLE
(Lightrec branch) Stretch displayed image to fill 16:9 screen better, specially on Wii U GamePad (FIX94)

### DIFF
--- a/Gamecube/libgui/GraphicsGX.cpp
+++ b/Gamecube/libgui/GraphicsGX.cpp
@@ -51,7 +51,7 @@ Graphics::Graphics(GXRModeObj *rmode)
 	case VIDEOMODE_AUTO:
 		//vmode = VIDEO_GetPreferredMode(NULL);
 		vmode = VIDEO_GetPreferredMode(&vmode_phys);
-#if 0
+#if 1
 		if(CONF_GetAspectRatio()) {
 			vmode->viWidth = 678;
 			vmode->viXOrigin = (VI_MAX_WIDTH_PAL - 678) / 2;


### PR DESCRIPTION
Reference: https://github.com/FIX94/mupen64gc-fix94/commit/e5d9d9cc9fea4b1abaf79635cd00893a56a03ff9#diff-d19b65d89a8449895ac90db875ea00c1917da5cca40d08638d6c2631fa715c6fR52
Originally made to Wii64 but this works on WiiStation too.