### PR TITLE
Revert commit 388fc3db (Re-add RCnt2 (system timing) fix [PE2, VH1, VH2])

### DIFF
--- a/psxcounters.c
+++ b/psxcounters.c
@@ -441,17 +441,17 @@ u32 psxRcntRcount( u32 index )
     count = _psxRcntRcount( index );
 
     // Parasite Eve 2 fix.
-//    if( Config.RCntFix )
-//    {
-//        if( index == 2 )
-//        {
-//            if( rcnts[index].counterState == CountToTarget )
-//            {
-//                //count /= BIAS;
-//                count = count >> 1;
-//            }
-//        }
-//    }
+    if( Config.RCntFix )
+    {
+        if( index == 2 )
+        {
+            if( rcnts[index].counterState == CountToTarget )
+            {
+                //count /= BIAS;
+                count = count >> 1;
+            }
+        }
+    }
 
     //verboseLog( 2, "[RCNT %i] rcount: %x\n", index, count );
 


### PR DESCRIPTION
This PR reverts the commit https://github.com/xjsxjs197/WiiSXRX_2022/commit/388fc3db, since from this commit the following games benefitied from this autoFix stopped working:

- Parasite Eve II
- Vandal Hearts
- Vandal Hearts II

Lightrec sometimes can't even play these games without special fixes such this one, so i decided to bring this fix back.
Tested personally and working.