### PR TITLE
Add libOGC 1.8.16 with IPC fix, with download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ Any help is appreciated.
 
 ## Compilation information
 
-* devkitPPC r29 + libOGC 1.8.16 + SDL + GNU Lightning + Lightrec
+* devkitPPC r29 + libOGC 1.8.16 (with the [IPC fix](https://github.com/devkitPro/libogc/commit/d91c59aaf37e54056af38d1244da0c5e28fabace) for fix issue [#81](https://github.com/xjsxjs197/WiiSXRX_2022/issues/81)) + SDL + GNU Lightning + Lightrec
 
-  You can download everything here: https://wii.leseratte10.de/devkitPro/
+  You can download devkitPPC r29 here: https://wii.leseratte10.de/devkitPro/
+
+  The compiled libOGC 1.8.16 with the IPC fix is here: https://github.com/xjsxjs197/WiiSXRX_2022/raw/main/libogc_1.8.16_ipcfix.zip
 
   The compiled SDL is here: https://github.com/xjsxjs197/WiiSXRX_2022/raw/main/libSDL.a
   


### PR DESCRIPTION
Since we can't use the latest libOGC (2.4.0) with devkitPPC r29, i just recompiled the source code from libOGC 1.8.16 which i added the commit https://github.com/devkitPro/libogc/commit/d91c59aaf37e54056af38d1244da0c5e28fabace in order for fix the issue https://github.com/xjsxjs197/WiiSXRX_2022/issues/81, for then publish here the "modified" libOGC 1.8.16 with the fix, with a download link on the README.