### PR TITLE
finish migrating properly from libOGC to libOGC2

### DIFF
--- a/Gamecube/Makefile_Wii
+++ b/Gamecube/Makefile_Wii
@@ -7,7 +7,7 @@ ifeq ($(strip $(DEVKITPPC)),)
 $(error "Please set DEVKITPPC in your environment. export DEVKITPPC=<path to>devkitPPC")
 endif
 
-include $(DEVKITPPC)/wii_rules
+include $(DEVKITPRO)/libogc2/wii_rules
 
 #---------------------------------------------------------------------------------
 # GPU Plugin (GX or Soft)

--- a/Gamecube/Makefile_Wii_Release
+++ b/Gamecube/Makefile_Wii_Release
@@ -7,7 +7,7 @@ ifeq ($(strip $(DEVKITPPC)),)
 $(error "Please set DEVKITPPC in your environment. export DEVKITPPC=<path to>devkitPPC")
 endif
 
-include $(DEVKITPPC)/wii_rules
+include $(DEVKITPRO)/libogc2/wii_rules
 
 #---------------------------------------------------------------------------------
 # GPU Plugin (GX or Soft)


### PR DESCRIPTION
Info: https://github.com/extremscorner/libogc2#readme

I saw you're now migrating from official libOGC to @Extrems' libOGC2, but Extrems states that you can migrate safely from libOGC to libOGC2 without having to delete your original libOGC, by just changing the locations of the rules on the Makefiles.

For use libOGC2, just download the latest artifacts from https://github.com/extremscorner/libogc2/actions , then extract its contents into the **C:/devkitPro/libogc2/** folder.