### PR TITLE
Fix PS1 GunCon cursor accuracy in "Force 16:9" screen mode (Jokippo)

### DIFF
--- a/Gamecube/PadSSSPSX.c
+++ b/Gamecube/PadSSSPSX.c
@@ -132,7 +132,9 @@ static void UpdateState (const int pad) //Note: pad = 0 or 1
 			virtualControllers[Control].control == &controller_WiimoteNunchuk){
 				global.padID[pad] = 0x63;
 				wpad = WPAD_Data(0);
-				cursorX = (wpad[virtualControllers[Control].number].ir.x/1.8)+80;
+				if(screenMode == 2)	cursorX = ((wpad[virtualControllers[Control].number].ir.x*848/640 - 104)/1.8)+80;
+				else cursorX = (wpad[virtualControllers[Control].number].ir.x/1.8)+80;
+				
 				cursorY = (wpad[virtualControllers[Control].number].ir.y/2); 
 				
 				if (!wpad[virtualControllers[Control].number].ir.valid){

--- a/Gamecube/libgui/InputStatusBar.cpp
+++ b/Gamecube/libgui/InputStatusBar.cpp
@@ -131,6 +131,7 @@ void InputStatusBar::drawComponent(Graphics& gfx)
 			controller_GC.available[(int)padAssign[i]] = (gc_connected & (1<<padAssign[i])) ? 1 : 0;
 			if (controller_GC.available[(int)padAssign[i]])
 			{
+				assign_controller(i, &controller_GC, (int)padAssign[i]);
 				gfx.setColor(activeColor);
 				IplFont::getInstance().drawInit(activeColor);
 //				gfx.setColor(controllerColors[i]);

--- a/PeopsSoftGPU/drawGX.c
+++ b/PeopsSoftGPU/drawGX.c
@@ -459,13 +459,18 @@ void GX_Flip(short width, short height, u8 * buffer, int pitch, u8 fmt)
 	GX_SetTevOp(GX_TEVSTAGE0, GX_PASSCLR);
 	GX_SetLineWidth(10, GX_TO_ZERO );
 	
-		for (i=0;i<2;i++){
+		for (i=0;i<4;i++){
 			if (controller_Wiimote.available[i] || controller_WiimoteNunchuk.available[i]){
 				wpad = WPAD_Data(0);
 				if (!wpad[i].ir.valid) continue;
 				cursorX = wpad[i].ir.x;
 				cursorY = wpad[i].ir.y; 
-				if (i){r=255; g=0; b=0;} else{r=0; g=255; b=0;}
+				switch (i){
+					case 0: r=0; g=255; b=0;break;
+					case 1: r=255; g=0; b=0;break;
+					case 2: r=0; g=0; b=255;break;
+					case 3: r=0; g=255; b=255;break;
+				}
 				
 				drawCircle(cursorX, cursorY, 20, 10, r, g, b);
 				drawLine(cursorX, cursorY-5, cursorX, cursorY+5, r, g, b);

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ WiiStation (formely WiiSXRX_2022), is a Sony PlayStation 1 (PS1/PSX/PSone) emula
 * Combined the DFSound module from PCSX-ReARMed and used the SDL library.
   The sound quality of the system has been greatly improved.
 
-* Adding the new, updated PSX dynamic recompiler [Lightrec](https://github.com/pcercuei/lightrec) by pcercuei, the speed/performance of the emulation is greatly improved. The original old PPC dynarec is kept as an option in case
+* Adding the new, updated PSX dynamic recompiler [Lightrec](https://github.com/pcercuei/lightrec) by pcercuei, the speed/performance of the emulation is greatly improved. The original old (and fixed/improved) PPC dynarec is kept as an option in case compatibility or speed changes much.
 
 * 240p support!
 


### PR DESCRIPTION
While the GunCon support via Wiimote IR works, it only worked fine if the screen mode was set to "4:3" or "16:9".
If set to "Force 16:9", the lightgun cursor wasn't so accurate.

This fixes that.
Fix by @Jokippo.