### PR TITLE
Add analog stick adjust, fix Standard controller detection, fix Vib-Ribbon when in 240p (Jokippo)

### DIFF
--- a/Gamecube/PlugPAD.c
+++ b/Gamecube/PlugPAD.c
@@ -211,6 +211,7 @@ int load_configurations(FILE* f, controller_t* controller){
 			getPointer(controller->menu_combos, controller->num_menu_combos);
 		fread(&controller->config_slot[i].invertedYL, 4, 1, f);
 		fread(&controller->config_slot[i].invertedYR, 4, 1, f);
+		fread(&controller->config_slot[i].sensitivity, 4, 1, f);
 	}
 
 	if (loadButtonSlot != LOADBUTTON_DEFAULT) {
@@ -257,6 +258,7 @@ void save_configurations(FILE* f, controller_t* controller){
 		fwrite(&controller->config_slot[i].exit->index, 4, 1, f);
 		fwrite(&controller->config_slot[i].invertedYL, 4, 1, f);
 		fwrite(&controller->config_slot[i].invertedYR, 4, 1, f);
+		fwrite(&controller->config_slot[i].sensitivity, 4, 1, f);
 	}
 }
 

--- a/Gamecube/gc_input/controller-Classic.c
+++ b/Gamecube/gc_input/controller-Classic.c
@@ -276,6 +276,7 @@ controller_t controller_Classic =
 	    .exit       = &menu_combos[2], // Home
 	    .invertedYL = 0,
 	    .invertedYR = 0,
+		.sensitivity = 1.0,
 	  }
 	 };
 

--- a/Gamecube/gc_input/controller-GC.c
+++ b/Gamecube/gc_input/controller-GC.c
@@ -234,6 +234,7 @@ controller_t controller_GC =
 	    .exit       = &menu_combos[1], // Start+X
 	    .invertedYL = 0,
 	    .invertedYR = 0,
+		.sensitivity = 1.0,
 	  }
 	 };
 

--- a/Gamecube/gc_input/controller-WUPC.c
+++ b/Gamecube/gc_input/controller-WUPC.c
@@ -224,6 +224,7 @@ controller_t controller_WiiUPro =
 		.exit = &menu_combos[2], // Home
 		.invertedYL = 0,
 		.invertedYR = 0,
+		.sensitivity = 1.0,
 	}
 };
 

--- a/Gamecube/gc_input/controller-WiiDRC.c
+++ b/Gamecube/gc_input/controller-WiiDRC.c
@@ -231,6 +231,7 @@ controller_t controller_WiiUGamepad =
 		.exit = &menu_combos[2], // Home
 		.invertedYL = 0,
 		.invertedYR = 0,
+		.sensitivity = 1.0,
 	}
 };
 

--- a/Gamecube/gc_input/controller-WiimoteNunchuk.c
+++ b/Gamecube/gc_input/controller-WiimoteNunchuk.c
@@ -364,6 +364,7 @@ controller_t controller_WiimoteNunchuk =
 	    .exit       = &menu_combos[0], // 1+2
 	    .invertedYL = 0,
 	    .invertedYR = 0,
+		.sensitivity = 1.0,
 	  }
 	 };
 

--- a/Gamecube/gc_input/controller.h
+++ b/Gamecube/gc_input/controller.h
@@ -83,6 +83,7 @@ typedef struct {
 	button_tp START, SELECT;
 	button_tp analogL, analogR, exit;
 	int invertedYL, invertedYR;
+	float sensitivity;
 } controller_config_t;
 
 typedef struct {

--- a/Gamecube/libgui/GraphicsGX.cpp
+++ b/Gamecube/libgui/GraphicsGX.cpp
@@ -83,7 +83,7 @@ extern "C" void switchToTVMode(short dWidth, short dHeight, bool retMenu){
 		dHeight = rmode->viHeight;
 	
 	
-	if ((dHeight > 256))
+	if ((dHeight > 288))
 	{
 		if(!retMenu)
 		{

--- a/Gamecube/menu/ConfigureButtonsFrame.cpp
+++ b/Gamecube/menu/ConfigureButtonsFrame.cpp
@@ -63,18 +63,20 @@ void Func_ToggleInvertYL();
 void Func_ToggleInvertYR();
 void Func_ToggleButtonL3();
 void Func_ToggleButtonR3();
+void Func_SensMinus();
+void Func_SensPlus();
 
 void Func_ReturnFromConfigureButtonsFrame();
 
 
-#define NUM_FRAME_BUTTONS 26
+#define NUM_FRAME_BUTTONS 28
 #define FRAME_BUTTONS configureButtonsFrameButtons
 #define FRAME_STRINGS configureButtonsFrameStrings
-#define NUM_FRAME_TEXTBOXES 2
+#define NUM_FRAME_TEXTBOXES 3
 #define FRAME_TEXTBOXES configureButtonsFrameTextBoxes
 #define TITLE_STRING configureButtonsTitleString
 
-static char FRAME_STRINGS[27][20] =
+static char FRAME_STRINGS[32][20] =
 	{ "Next Pad",
 	  "Load Default",
 	  "Slot 1",
@@ -101,7 +103,12 @@ static char FRAME_STRINGS[27][20] =
 	  "Invert Y R",
 	  "Btn L3",
 	  "Btn R3",
-	  "Menu:"};
+	  "???",
+	  "???",
+	  "-",
+	  "x1.0",
+	  "Menu:",
+	  "+"};
 
 static char TITLE_STRING[50] = "Gamecube Pad 1 to PSX Pad 1 Mapping";
 
@@ -126,16 +133,16 @@ struct ButtonInfo
 	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[1],	175.0,	 80.0,	145.0,	40.0,	24,	 8,	 0,	 2,	Func_DefaultConfig,		Func_ReturnFromConfigureButtonsFrame }, // Restore Default Config
 	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[2],	340.0,	 80.0,	 80.0,	40.0,	25,	 9,	 1,	 3,	Func_ToggleConfigSlot,	Func_ReturnFromConfigureButtonsFrame }, // Cycle Through Config Slots
 	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[3],	440.0,	 80.0,	 70.0,	40.0,	23,	10,	 2,	 4,	Func_LoadConfig,		Func_ReturnFromConfigureButtonsFrame }, // Load Config
-	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[4],	530.0,	 80.0,	 70.0,	40.0,	23,	10,	 3,	 0,	Func_SaveConfig,		Func_ReturnFromConfigureButtonsFrame }, // Save Config
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[4],	530.0,	 80.0,	 70.0,	40.0,	23,	27,	 3,	 0,	Func_SaveConfig,		Func_ReturnFromConfigureButtonsFrame }, // Save Config
 
-	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[5],	 30.0,	160.0,	100.0,	40.0,	 0,	12,	10,	 6,	Func_ToggleButtonExit,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Button Exit
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[5],	 30.0,	160.0,	100.0,	40.0,	 0,	12,	26,	 6,	Func_ToggleButtonExit,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Button Exit
 
 	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[6],	140.0,	130.0,	 80.0,	40.0,	 0,	 7,	 5,	 8,	Func_ToggleButtonL1,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Button L1
 	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[7],	140.0,	180.0,	 80.0,	40.0,	 6,	12,	 5,	 8,	Func_ToggleButtonL2,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Button L2
 	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[8],	235.0,	140.0,	 80.0,	40.0,	 1,	20,	 6,	 9,	Func_ToggleButtonSelect,Func_ReturnFromConfigureButtonsFrame }, // Toggle Button Select
 	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[9],	325.0,	140.0,	 80.0,	40.0,	 2,	21,	 8,	10,	Func_ToggleButtonStart,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Button Start
-	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[10],	420.0,	130.0,	 80.0,	40.0,	 3,	11,	 9,	 5,	Func_ToggleButtonR1,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Button R1
-	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	420.0,	180.0,	 80.0,	40.0,	10,	16,	 9,	 5,	Func_ToggleButtonR2,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Button R2
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[10],	420.0,	130.0,	 80.0,	40.0,	 3,	11,	 9,	 27,Func_ToggleButtonR1,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Button R1
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	420.0,	180.0,	 80.0,	40.0,	10,	16,	 9,	 27,Func_ToggleButtonR2,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Button R2
 
 	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[12],	 75.0,	230.0,	 80.0,	40.0,	 5,	13,	16,	16,	Func_ToggleButtonDup,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Button D-up
 	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[13],	 30.0,	280.0,	 80.0,	40.0,	12,	15,	18,	14,	Func_ToggleButtonDleft,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Button D-left
@@ -153,6 +160,8 @@ struct ButtonInfo
 	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[23],	415.0,	395.0,	130.0,	40.0,	19,	 3,	25,	22,	Func_ToggleInvertYR,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Analog Invert Y R
 	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[24],	235.0,	395.0,	 80.0,	40.0,	20,	 1,	22,	25,	Func_ToggleButtonL3,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Button L3
 	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[25],	325.0,	395.0,	 80.0,	40.0,	21,	 2,	24,	23,	Func_ToggleButtonR3,	Func_ReturnFromConfigureButtonsFrame }, // Toggle Button R3
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[31],	575.0,	140.0,	 50.0,	40.0,	4,	16,	27,	5,	Func_SensPlus,			Func_ReturnFromConfigureButtonsFrame }, // Stick Sensitivity +
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[28],	515.0,	140.0,	 50.0,	40.0,	4,	16,	10,	26,	Func_SensMinus,			Func_ReturnFromConfigureButtonsFrame }, // Stick Sensitivity -
 };
 
 struct TextBoxInfo
@@ -166,7 +175,8 @@ struct TextBoxInfo
 } FRAME_TEXTBOXES[NUM_FRAME_TEXTBOXES] =
 { //	textBox	textBoxString		x		y		scale	centered
 	{	NULL,	TITLE_STRING,		320.0,	 50.0,	 1.0,	true }, // ______ Pad X to N64 Pad Y Mapping
-	{	NULL,	FRAME_STRINGS[26],	 80.0,	145.0,	 0.9,	true }, // Menu Combo
+	{	NULL,	FRAME_STRINGS[30],	 80.0,	145.0,	 0.9,	true }, // Menu Combo
+	{	NULL,	FRAME_STRINGS[29],	 565.0,	210.0,	 0.9,	true }, // Stick Sensitivity
 };
 
 ConfigureButtonsFrame::ConfigureButtonsFrame()
@@ -190,10 +200,7 @@ ConfigureButtonsFrame::ConfigureButtonsFrame()
 												FRAME_BUTTONS[i].x+FRAME_BUTTONS[i].width, FRAME_BUTTONS[i].y, 
 												FRAME_BUTTONS[i].y+FRAME_BUTTONS[i].height);
 	}
-	for (int i = 0; i < 5; i++)
-		FRAME_BUTTONS[i].button->setFontSize(0.8);
-	for (int i = 5; i < NUM_FRAME_BUTTONS; i++)
-		FRAME_BUTTONS[i].button->setFontSize(0.7);
+
 
 	for (int i = 0; i < NUM_FRAME_TEXTBOXES; i++)
 	{
@@ -331,6 +338,8 @@ void ConfigureButtonsFrame::activateSubmenu(int submenu)
 				FRAME_BUTTONS[i].button->setActive(true);
 				FRAME_BUTTONS[i].button->setVisible(true);
 			}
+			FRAME_TEXTBOXES[1].textBox->setVisible(true);
+			FRAME_TEXTBOXES[2].textBox->setVisible(true);
 		}
 		else{
 			FRAME_BUTTONS[0].button->setNextFocus(menu::Focus::DIRECTION_UP, NULL);
@@ -357,6 +366,9 @@ void ConfigureButtonsFrame::activateSubmenu(int submenu)
 			}
 			FRAME_BUTTONS[19].button->setActive(true);
 			FRAME_BUTTONS[19].button->setVisible(true);
+			
+			FRAME_TEXTBOXES[1].textBox->setVisible(false);
+			FRAME_TEXTBOXES[2].textBox->setVisible(false);
 		}
 
 		//Assign text to each button
@@ -387,6 +399,8 @@ void ConfigureButtonsFrame::activateSubmenu(int submenu)
 			strcpy(FRAME_STRINGS[23], "Normal Y");
 		strcpy(FRAME_STRINGS[24], currentConfig->L3->name);
 		strcpy(FRAME_STRINGS[25], currentConfig->R3->name);
+		if (currentConfig->sensitivity < 0.1) currentConfig->sensitivity = 1.0;
+		sprintf(FRAME_STRINGS[29], "Stick: x%.1f", currentConfig->sensitivity);
 	}
 }
 
@@ -719,6 +733,26 @@ void Func_ToggleInvertYR()
 	{
 		virtualControllers[activePad].config->invertedYR = 1;
 		strcpy(FRAME_STRINGS[23], "Inverted Y");
+	}
+}
+
+void Func_SensPlus()
+{
+	float sensitivity = virtualControllers[activePad].config->sensitivity;
+	if (sensitivity<2)
+	{
+		virtualControllers[activePad].config->sensitivity += 0.1;
+		sprintf(FRAME_STRINGS[29], "Stick: x%.1f", virtualControllers[activePad].config->sensitivity);
+	}
+}
+
+void Func_SensMinus()
+{
+	float sensitivity = virtualControllers[activePad].config->sensitivity;
+	if (sensitivity>0.2)
+	{
+		virtualControllers[activePad].config->sensitivity -= 0.1;
+		sprintf(FRAME_STRINGS[29], "Stick: x%.1f", virtualControllers[activePad].config->sensitivity);
 	}
 }
 

--- a/lightrec.c
+++ b/lightrec.c
@@ -39,7 +39,7 @@ static char *name = "sd:/WiiStation/WiiStation.elf";
 u32 event_cycles[PSXINT_COUNT];
 u32 next_interupt;
 
-static bool use_lightrec_interpreter = false;  
+static bool use_lightrec_interpreter = false;
 static bool use_pcsx_interpreter = false;
 static bool booting;
 


### PR DESCRIPTION
Like the title says, this merges the following changes made to WiiStation by @Jokippo:

- Add options for adjust the sensitivity of the analog sticks in the emulated PS1 controller (only if the controller type is set to Analog/DualShock). The default setting is 1.0x multiplier.
- Fixes Standard controller detection, which in some games, the Standard controller wasn't being recognized.
- Fixes Vib-Ribbon not being displayed correctly if the 240p option is enabled.