### PR TITLE
lightrec: Emulate BREAK and Syscall instructions (pcercuei)

### DIFF
--- a/lightrec.c
+++ b/lightrec.c
@@ -558,7 +558,9 @@ static void lightrec_plugin_execute_internal(bool block_only)
 	}
 
 	if (flags & LIGHTREC_EXIT_SYSCALL)
-		psxException(0x20, 0);
+		psxException(8 << 2, 0); // R3000A syscall instruction
+	if (flags & LIGHTREC_EXIT_BREAK)
+		psxException(9 << 2, 0); // R3000A breakpoint - a break instruction
 
 	//if (booting && (psxRegs.pc & 0xff800000) == 0x80000000)
 	//	booting = false;

--- a/r3000a.h
+++ b/r3000a.h
@@ -25,6 +25,20 @@
 #include "psxcounters.h"
 #include "psxbios.h"
 
+/* R3000A exceptions list:
+
+- R3000E_Int = 0      // Interrupt
+- R3000E_AdEL = 4     // Address error (on load/I-fetch)
+- R3000E_AdES = 5     // Address error (on store)
+- R3000E_IBE = 6      // Bus error (instruction fetch)
+- R3000E_DBE = 7      // Bus error (data load/store)
+- R3000E_Syscall = 8  // syscall instruction
+- R3000E_Bp = 9       // Breakpoint - a break instruction
+- R3000E_RI = 10      // reserved instruction
+- R3000E_CpU = 11     // Co-Processor unusable
+- R3000E_Ov = 12      // arithmetic overflow
+*/
+
 typedef struct {
 	int  (*Init)();
 	void (*Reset)();


### PR DESCRIPTION
Some games (EA Sports F1 2000, maybe others) require BREAK to be emulated properly.