### PR TITLE
Add autoFix for Studio 33 F1 games on Lightrec, tidy up Syscall/Break emulation in Lightrec, add Syscall/Break emulation on old PPC dynarec

### DIFF
--- a/Gamecube/menu/CurrentRomFrame.cpp
+++ b/Gamecube/menu/CurrentRomFrame.cpp
@@ -46,6 +46,7 @@ extern int PerGameFix_timing; 		// variable for see if game has timing autoFix
 extern int PerGameFix_GPUbusy; 		// variable for see if game has GPU 'Fake Busy States' (dwEmuFixes) autoFix
 extern int PerGameFix_specialCorrect; 	// variable for see if game has special correction (dwActFixes) autoFix
 extern int PerGameFix_pR3000A; 		// variable for see if game has pR3000A autoFix
+extern int PerGameFix_LightrecHacks; 	// variable for see if game uses hacks from Lightrec
 
 void Func_ShowRomInfo();
 void Func_ResetROM();
@@ -171,6 +172,11 @@ void Func_ShowRomInfo()
   if (PerGameFix_specialCorrect)
   {
   	sprintf(buffer, "Special game auto fixed\n");
+  	strcat(RomInfo,buffer);
+  }
+  if (PerGameFix_LightrecHacks)
+  {
+  	sprintf(buffer, "Applied Lightrec hacks\n");
   	strcat(RomInfo,buffer);
   }
   if (PerGameFix_pR3000A)

--- a/Gamecube/menu/FileBrowserFrame.cpp
+++ b/Gamecube/menu/FileBrowserFrame.cpp
@@ -47,6 +47,13 @@ int PerGameFix_timing; 		// variable for see if game has timing autoFix
 int PerGameFix_GPUbusy; 	// variable for see if game has GPU 'Fake Busy States' (dwEmuFixes) autoFix
 int PerGameFix_specialCorrect; 	// variable for see if game has special correction (dwActFixes) autoFix
 int PerGameFix_pR3000A; 	// variable for see if game has pR3000A autoFix
+int PerGameFix_LightrecHacks; 	// variable for see if game uses hacks from Lightrec
+
+/* Corresponds to LIGHTREC_OPT_INV_DMA_ONLY of lightrec.h */
+#define LIGHTREC_HACK_INV_DMA_ONLY (1 << 0)
+
+// define variable for store and handle Lightrec hacks
+u32 lightrec_hacks;
 
 void Func_PrevPage();
 void Func_NextPage();
@@ -607,6 +614,40 @@ static void CheckGameAutoFix(void)
 	        PerGameFix_specialCorrect = 1;
         }
     }
+
+    // Apply LIGHTREC_HACK_INV_DMA_ONLY hack for some games when in Lightrec
+    autoFixLen = 13;
+    char LightrecDMAhackAutoFixGames[autoFixLen][10] = {
+        // Formula One Arcade
+         "SCES03886" // PAL
+
+        // Formula One '99
+        ,"SLUS00870" // NTSC-U
+        ,"SCPS10101" // NTSC-J
+        ,"SCES01979" // PAL
+        ,"SLES01979" // PAL
+
+        // Formula One 2000
+        ,"SLUS01134" // NTSC-U
+        ,"SCES02777" // PAL
+        ,"SCES02778" // PAL (France, Germany)
+        ,"SCES02779" // PAL (Italy, Spain)
+
+        // Formula One 2001
+        ,"SCES03404" // PAL
+        ,"SCES03423" // PAL (France, Germany)
+        ,"SCES03424" // PAL (Italy, Spain)
+        ,"SCES03524" // PAL (Russia)
+    };
+    lightrec_hacks = 0;
+    PerGameFix_LightrecHacks = 0;
+    for (i = 0; i < autoFixLen; i++)
+    {
+	if (ChkString(CdromId, LightrecDMAhackAutoFixGames[i], strlen(LightrecDMAhackAutoFixGames[i]))) {
+		lightrec_hacks = LIGHTREC_HACK_INV_DMA_ONLY;
+			PerGameFix_LightrecHacks = 1;
+        }
+    }
 }
 
 static void CheckGameR3000AutoFix(void)
@@ -745,6 +786,11 @@ void fileBrowserFrame_LoadFile(int i)
             if (dwActFixes)
             {
                 sprintf(buffer, "Special game auto fixed\n");
+                strcat(RomInfo,buffer);
+            }
+            if (lightrec_hacks)
+            {
+                sprintf(buffer, "Applied Lightrec hacks\n");
                 strcat(RomInfo,buffer);
             }
             // Switches for painting textured quads as 2 triangles (small glitches, but better shading!)

--- a/lightrec.c
+++ b/lightrec.c
@@ -417,6 +417,8 @@ static int lightrec_plugin_init(void)
 			lightrec_map, ARRAY_SIZE(lightrec_map),
 			&lightrec_ops);
 
+	lightrec_set_unsafe_opt_flags(lightrec_state, lightrec_hacks);
+
 	signal(SIGPIPE, exit);
 
 	return 0;
@@ -578,6 +580,8 @@ static void lightrec_plugin_execute_internal(bool block_only)
 static void lightrec_plugin_execute(void)
 {
 	extern int stop;
+
+	lightrec_set_unsafe_opt_flags(lightrec_state, lightrec_hacks);
 
 	if (!booting)
 		lightrec_plugin_sync_regs_from_pcsx();

--- a/lightrec.c
+++ b/lightrec.c
@@ -562,9 +562,9 @@ static void lightrec_plugin_execute_internal(bool block_only)
 	}
 
 	if (flags & LIGHTREC_EXIT_SYSCALL)
-		psxException(8 << 2, 0); // R3000A syscall instruction
+		psxException(0x20, 0); // R3000A syscall instruction
 	if (flags & LIGHTREC_EXIT_BREAK)
-		psxException(9 << 2, 0); // R3000A breakpoint - a break instruction
+		psxException(0x24, 0); // R3000A breakpoint - a break instruction
 
 	//if (booting && (psxRegs.pc & 0xff800000) == 0x80000000)
 	//	booting = false;

--- a/lightrec.c
+++ b/lightrec.c
@@ -417,8 +417,6 @@ static int lightrec_plugin_init(void)
 			lightrec_map, ARRAY_SIZE(lightrec_map),
 			&lightrec_ops);
 
-	lightrec_set_unsafe_opt_flags(lightrec_state, lightrec_hacks);
-
 	signal(SIGPIPE, exit);
 
 	return 0;
@@ -624,6 +622,8 @@ static void lightrec_plugin_reset(void)
 
 	regs->cp0[12] = 0x10900000; // COP0 enabled | BEV = 1 | TS = 1
 	regs->cp0[15] = 0x00000002; // PRevID = Revision ID, same as R3000A
+
+	lightrec_set_unsafe_opt_flags(lightrec_state, lightrec_hacks);
 
 	//booting = true;
 }

--- a/lightrec.c
+++ b/lightrec.c
@@ -43,6 +43,8 @@ static bool use_lightrec_interpreter = false;
 static bool use_pcsx_interpreter = false;
 static bool booting;
 
+extern u32 lightrec_hacks;
+
 enum my_cp2_opcodes {
 	OP_CP2_RTPS		= 0x01,
 	OP_CP2_NCLIP		= 0x06,
@@ -414,6 +416,8 @@ static int lightrec_plugin_init(void)
 	lightrec_state = lightrec_init(name,
 			lightrec_map, ARRAY_SIZE(lightrec_map),
 			&lightrec_ops);
+
+	lightrec_set_unsafe_opt_flags(lightrec_state, lightrec_hacks);
 
 	signal(SIGPIPE, exit);
 

--- a/ppc/pR3000A.c
+++ b/ppc/pR3000A.c
@@ -2733,6 +2733,7 @@ static void recSRAV() {
 }
 
 //REC_SYS(SYSCALL);
+void psxSYSCALL();
 static void recSYSCALL() {
 //	dump=1;
 	#ifdef SHOW_DEBUG
@@ -2752,10 +2753,23 @@ static void recSYSCALL() {
 }
 
 //REC_SYS(BREAK);
+void psxBREAK();
 static void recBREAK() {
+//	dump=1;
     #ifdef SHOW_DEBUG
     printFunctionLog();
     #endif // SHOW_DEBUG
+	iFlushRegs(0);
+
+	ReserveArgs(2);
+	LIW(PutHWRegSpecial(PSXPC), pc - 4);
+	LIW(PutHWRegSpecial(ARG1), 0x24);
+	LIW(PutHWRegSpecial(ARG2), (branch == 1 ? 1 : 0));
+	FlushAllHWReg();
+	CALLFunc ((u32)psxException);
+
+	branch = 2;
+	iRet();
 }
 
 //REC_FUNC(MFHI);


### PR DESCRIPTION
Like the title says, i have changed these things in both Lightrec and old PPC dynarec:

- Added autoFix for the problematic F1 games developed by Studio 33 (Formula One Arcade, Formula One '99/2000/2001). These will only boot when in Lightrec. (There are still some few crashes, so for play this you'll still have to stick at Interpreter for now)
- Tidy up SYSCALL/BREAK exceptions emulation in Lightrec.
- Add SYSCALL/BREAK exceptions emulation in old PPC dynarec. Makes EA Sports F1 2000 to be bootable and playable in old PPC dynarec.