### PR TITLE
Use minimum GX fifo size (pcercuei)

### DIFF
--- a/Gamecube/GamecubeMain.cpp
+++ b/Gamecube/GamecubeMain.cpp
@@ -88,7 +88,6 @@ void LidInterrupt();
 unsigned int* xfb[2] = { NULL, NULL };	/*** Framebuffers ***/
 int whichfb = 0;        /*** Frame buffer toggle ***/
 GXRModeObj *vmode;				/*** Graphics Mode Object ***/
-#define DEFAULT_FIFO_SIZE ( 256 * 1024 )
 BOOL hasLoadedISO = FALSE;
 fileBrowser_file isoFile;  //the ISO file
 fileBrowser_file cddaFile; //the CDDA file

--- a/Gamecube/libgui/GraphicsGX.cpp
+++ b/Gamecube/libgui/GraphicsGX.cpp
@@ -21,8 +21,6 @@
 #include <math.h>
 #include "GraphicsGX.h"
 
-#define DEFAULT_FIFO_SIZE		(256 * 1024)
-
 GXRModeObj TVMODE_240p =
 {
 	VI_TVMODE_EURGB60_DS, 	// viDisplayMode
@@ -266,9 +264,9 @@ void Graphics::init()
 	void *gpfifo = NULL;
 	GXColor background = {0, 0, 0, 0xff};
 
-	gpfifo = memalign(32,DEFAULT_FIFO_SIZE);
-	memset(gpfifo,0,DEFAULT_FIFO_SIZE);
-	GX_Init(gpfifo,DEFAULT_FIFO_SIZE);
+	gpfifo = memalign(32,GX_FIFO_MINSIZE);
+	memset(gpfifo,0,GX_FIFO_MINSIZE);
+	GX_Init(gpfifo,GX_FIFO_MINSIZE);
 	GX_SetCopyClear(background, GX_MAX_Z24);
 
 	GX_SetViewport(0,0,vmode->fbWidth,vmode->efbHeight,0,1);


### PR DESCRIPTION
We don't need more than that.

This reduces RAM usage by 192 KiB.