### PR TITLE
add Bomberman Fantasy Race to database for hack "(GPU) slow linked list walking"

### DIFF
--- a/database.c
+++ b/database.c
@@ -25,6 +25,9 @@ static const char * const cdr_read_hack_db[] =
 
 static const char * const gpu_slow_llist_db[] =
 {
+    /* Bomberman Fantasy Race */
+    "SLES01712", "SLPS01525", "SLPS91138", "SLPM87102",
+    "SLUS00823",
     /* Crash Bash */
     "SCES02834", "SCUS94570", "SCUS94616", "SCUS94654",
     /* Final Fantasy IV */


### PR DESCRIPTION
https://github.com/libretro/pcsx_rearmed/commit/fe564285d821692def083c0d3579ce71496f687a

Without this hack, the game Bomberman Fantasy Race has the invisible Retry/Quit menu.

**By now this hack ("(GPU) slow linked list walking") isn't implemented in WiiStation, but i'll leave this entry so when the hack gets implemented, we can see almost inmediately the result.**