### PR TITLE
Update Lightrec until git b8ce1f3 (24/11/2023) and improve hack around ICache emulation (pcercuei)

### DIFF
--- a/deps/lightrec/lightrec.c
+++ b/deps/lightrec/lightrec.c
@@ -1559,6 +1559,7 @@ static void lightrec_reap_opcode_list(struct lightrec_state *state, void *data)
 int lightrec_compile_block(struct lightrec_cstate *cstate,
 			   struct block *block)
 {
+	u32 was_dead[ARRAY_SIZE(cstate->targets) / 8];
 	struct lightrec_state *state = cstate->state;
 	struct lightrec_branch_target *target;
 	bool fully_tagged = false;
@@ -1677,23 +1678,14 @@ int lightrec_compile_block(struct lightrec_cstate *cstate,
 	/* Add compiled function to the LUT */
 	lut_write(state, lut_offset(block->pc), block->function);
 
-	if (ENABLE_THREADED_COMPILER)
-		lightrec_reaper_continue(state->reaper);
-
 	/* Detect old blocks that have been covered by the new one */
-	for (i = 0; i < cstate->nb_targets; i++) {
+	for (i = 0; ENABLE_THREADED_COMPILER && i < cstate->nb_targets; i++) {
 		target = &cstate->targets[i];
 
 		if (!target->offset)
 			continue;
 
 		offset = block->pc + target->offset * sizeof(u32);
-
-		/* Pause the reaper while we search for the block until we set
-		 * the BLOCK_IS_DEAD flag, otherwise the block may be removed
-		 * under our feet. */
-		if (ENABLE_THREADED_COMPILER)
-			lightrec_reaper_pause(state->reaper);
 
 		block2 = lightrec_find_block(state->block_cache, offset);
 		if (block2) {
@@ -1703,17 +1695,24 @@ int lightrec_compile_block(struct lightrec_cstate *cstate,
 			/* Set the "block dead" flag to prevent the dynarec from
 			 * recompiling this block */
 			old_flags = block_set_flags(block2, BLOCK_IS_DEAD);
+
+			if (old_flags & BLOCK_IS_DEAD)
+				was_dead[i / 32] |= BIT(i % 32);
+			else
+				was_dead[i / 32] &= ~BIT(i % 32);
 		}
 
-		if (ENABLE_THREADED_COMPILER) {
-			lightrec_reaper_continue(state->reaper);
+		/* If block2 was pending for compilation, cancel it.
+		 * If it's being compiled right now, wait until it finishes. */
+		if (block2)
+			lightrec_recompiler_remove(state->rec, block2);
+	}
 
-			/* If block2 was pending for compilation, cancel it.
-			 * If it's being compiled right now, wait until it
-			 * finishes. */
-			if (block2)
-				lightrec_recompiler_remove(state->rec, block2);
-		}
+	for (i = 0; i < cstate->nb_targets; i++) {
+		target = &cstate->targets[i];
+
+		if (!target->offset)
+			continue;
 
 		/* We know from now on that block2 (if present) isn't going to
 		 * be compiled. We can override the LUT entry with our new
@@ -1721,6 +1720,8 @@ int lightrec_compile_block(struct lightrec_cstate *cstate,
 		offset = lut_offset(block->pc) + target->offset;
 		lut_write(state, offset, jit_address(target->label));
 
+		offset = block->pc + target->offset * sizeof(u32);
+		block2 = lightrec_find_block(state->block_cache, offset);
 		if (block2) {
 			pr_debug("Reap block 0x%08x as it's covered by block "
 				 "0x%08x\n", block2->pc, block->pc);
@@ -1729,13 +1730,16 @@ int lightrec_compile_block(struct lightrec_cstate *cstate,
 			if (!ENABLE_THREADED_COMPILER) {
 				lightrec_unregister_block(state->block_cache, block2);
 				lightrec_free_block(state, block2);
-			} else if (!(old_flags & BLOCK_IS_DEAD)) {
+			} else if (!(was_dead[i / 32] & BIT(i % 32))) {
 				lightrec_reaper_add(state->reaper,
 						    lightrec_reap_block,
 						    block2);
 			}
 		}
 	}
+
+	if (ENABLE_THREADED_COMPILER)
+		lightrec_reaper_continue(state->reaper);
 
 	if (ENABLE_DISASSEMBLER) {
 		pr_debug("Compiling block at PC: 0x%08x\n", block->pc);
@@ -1941,7 +1945,7 @@ struct lightrec_state * lightrec_init(char *argv0,
 	else
 		lut_size = CODE_LUT_SIZE * sizeof(void *);
 
-	init_jit(argv0);
+	init_jit_with_debug(argv0, stdout);
 
 	state = calloc(1, sizeof(*state) + lut_size);
 	if (!state)

--- a/deps/lightrec/optimizer.c
+++ b/deps/lightrec/optimizer.c
@@ -299,6 +299,9 @@ static bool reg_is_dead(const struct opcode *list, unsigned int offset, u8 reg)
 		if (opcode_writes_register(list[i].c, reg))
 			return true;
 
+		if (is_syscall(list[i].c))
+			return false;
+
 		if (has_delay_slot(list[i].c)) {
 			if (op_flag_no_ds(list[i].flags) ||
 			    opcode_reads_register(list[i + 1].c, reg))

--- a/lightrec.c
+++ b/lightrec.c
@@ -585,7 +585,8 @@ static void lightrec_plugin_execute_block(enum blockExecCaller caller)
 
 static void lightrec_plugin_clear(u32 addr, u32 size)
 {
-	if (addr == 0 && size == UINT32_MAX)
+	if ((addr == 0 && size == UINT32_MAX)
+	    || (lightrec_hacks & LIGHTREC_OPT_INV_DMA_ONLY))
 		lightrec_invalidate_all(lightrec_state);
 	else
 		/* size * 4: PCSX uses DMA units */


### PR DESCRIPTION
Update Lightrec until git https://github.com/pcercuei/lightrec/commit/b8ce1f3dab45d7c665aa406a0ff183ae6565205d

Also make Lightrec plugin to invalidate the whole code buffer on each call to the .clear callback. This fixes a crash after finishing a race in Formula One Arcade, and does not seem to cause issues with the other F1 games.

Many thanks to @pcercuei.