### PR TITLE
Update GNU Lightning to latest for support JIT debug

### DIFF
--- a/deps/lightrec/lightrec.c
+++ b/deps/lightrec/lightrec.c
@@ -1945,7 +1945,7 @@ struct lightrec_state * lightrec_init(char *argv0,
 	else
 		lut_size = CODE_LUT_SIZE * sizeof(void *);
 
-	//init_jit_with_debug(argv0, stdout);
+	init_jit_with_debug(argv0, stdout);
 
 	state = calloc(1, sizeof(*state) + lut_size);
 	if (!state)


### PR DESCRIPTION
Seeing your commit https://github.com/xjsxjs197/WiiSXRX_2022/commit/ae7fc156b903022409472d3bf1382aacca389790, i saw the exact cause of this issue.

Update lightrec+Libogc2.zip file, for use the latest GNU Lightning library for PPC (devkitPPC).
Also reverts said commit since now with the latest GNU Lightning library it compiles fine.