### PR TITLE
add minimum GPU timing task, fix disc swapping in Arc the Lad III (notaz)

### DIFF
--- a/SoftGPU/gpulib_if.c
+++ b/SoftGPU/gpulib_if.c
@@ -274,16 +274,19 @@ void renderer_notify_scanout_x_change(int x, int w)
 {
 }
 
+#include "../gpulib/gpu_timing.h"
 extern const unsigned char cmd_lengths[256];
 
-int do_cmd_list(uint32_t *list, int list_len, int *last_cmd)
+int do_cmd_list(uint32_t *list, int list_len, int *cpu_cycles_out, int *last_cmd)
 {
   unsigned int cmd = 0, len;
   uint32_t *list_start = list;
   uint32_t *list_end = list + list_len;
+  u32 cpu_cycles = 0;
 
   for (; list < list_end; list += 1 + len)
   {
+    short *slist = (void *)list;
     cmd = GETLE32(list) >> 24;
     len = cmd_lengths[cmd];
     if (list + 1 + len > list_end) {
@@ -309,6 +312,8 @@ int do_cmd_list(uint32_t *list, int list_len, int *last_cmd)
 
         while(1)
         {
+          cpu_cycles += gput_line(0);
+
           if(list_position >= list_end) {
             cmd = -1;
             goto breakloop;
@@ -332,6 +337,8 @@ int do_cmd_list(uint32_t *list, int list_len, int *last_cmd)
 
         while(1)
         {
+          cpu_cycles += gput_line(0);
+
           if(list_position >= list_end) {
             cmd = -1;
             goto breakloop;
@@ -351,7 +358,6 @@ int do_cmd_list(uint32_t *list, int list_len, int *last_cmd)
 #ifdef TEST
       case 0xA0:          //  sys -> vid
       {
-        short *slist = (void *)list;
         u32 load_width = SWAP32(slist[4]);
         u32 load_height = SWAP32(slist[5]);
         u32 load_size = load_width * load_height;
@@ -360,6 +366,35 @@ int do_cmd_list(uint32_t *list, int list_len, int *last_cmd)
         break;
       }
 #endif
+
+      // timing
+      case 0x02:
+        cpu_cycles += gput_fill(LE2HOST32(slist[4]) & 0x3ff,
+            LE2HOST32(slist[5]) & 0x1ff);
+        break;
+      case 0x20 ... 0x23: cpu_cycles += gput_poly_base();    break;
+      case 0x24 ... 0x27: cpu_cycles += gput_poly_base_t();  break;
+      case 0x28 ... 0x2B: cpu_cycles += gput_quad_base();    break;
+      case 0x2C ... 0x2F: cpu_cycles += gput_quad_base_t();  break;
+      case 0x30 ... 0x33: cpu_cycles += gput_poly_base_g();  break;
+      case 0x34 ... 0x37: cpu_cycles += gput_poly_base_gt(); break;
+      case 0x38 ... 0x3B: cpu_cycles += gput_quad_base_g();  break;
+      case 0x3C ... 0x3F: cpu_cycles += gput_quad_base_gt(); break;
+      case 0x40 ... 0x47: cpu_cycles += gput_line(0);        break;
+      case 0x50 ... 0x57: cpu_cycles += gput_line(0);        break;
+      case 0x60 ... 0x63:
+        cpu_cycles += gput_sprite(LE2HOST32(slist[4]) & 0x3ff,
+            LE2HOST32(slist[5]) & 0x1ff);
+        break;
+      case 0x64 ... 0x67:
+        cpu_cycles += gput_sprite(LE2HOST32(slist[6]) & 0x3ff,
+            LE2HOST32(slist[7]) & 0x1ff);
+        break;
+      case 0x68 ... 0x6B: cpu_cycles += gput_sprite(1, 1);   break;
+      case 0x70 ... 0x73:
+      case 0x74 ... 0x77: cpu_cycles += gput_sprite(8, 8);   break;
+      case 0x78 ... 0x7B:
+      case 0x7C ... 0x7F: cpu_cycles += gput_sprite(16, 16); break;
     }
   }
 
@@ -367,6 +402,7 @@ breakloop:
   gpu.ex_regs[1] &= ~0x1ff;
   gpu.ex_regs[1] |= lGPUstatusRet & 0x1ff;
 
+  *cpu_cycles_out += cpu_cycles;
   *last_cmd = cmd;
   return list - list_start;
 }
@@ -419,3 +455,5 @@ void renderer_set_config(const struct rearmed_cbs *cbs)
   cbs->pl_set_gpu_caps(0);
  set_vram(gpu.vram);
 }
+
+// vim:ts=2:shiftwidth=2:expandtab

--- a/cdrom.c
+++ b/cdrom.c
@@ -429,26 +429,22 @@ void cdrLidSeekInterrupt(void)
 
 		// 02, 12, 10
 		if (!(cdr.StatP & STATUS_SHELLOPEN)) {
+			StopReading();
 			SetPlaySeekRead(cdr.StatP, 0);
 			cdr.StatP |= STATUS_SHELLOPEN;
 
 			// IIRC this sometimes doesn't happen on real hw
 			// (when lots of commands are sent?)
-			if (cdr.Reading) {
-				StopReading();
-				SetResultSize(2);
-				cdr.Result[0] = cdr.StatP | STATUS_SEEKERROR;
-				cdr.Result[1] = ERROR_SHELLOPEN;
-				setIrq(DiskError, 0x1006);
-			}
+			SetResultSize(2);
+			cdr.Result[0] = cdr.StatP | STATUS_SEEKERROR;
+			cdr.Result[1] = ERROR_SHELLOPEN;
 			if (cdr.CmdInProgress) {
 				psxRegs.interrupt &= ~(1 << PSXINT_CDR);
 				cdr.CmdInProgress = 0;
-				SetResultSize(2);
 				cdr.Result[0] = cdr.StatP | STATUS_ERROR;
 				cdr.Result[1] = ERROR_NOTREADY;
-				setIrq(DiskError, 0x1007);
 			}
+			setIrq(DiskError, 0x1006);
 
 			set_event(PSXINT_CDRLID, cdReadTime * 30);
 			break;

--- a/gpulib/gpu.h
+++ b/gpulib/gpu.h
@@ -164,7 +164,7 @@ extern struct psx_gpu gpu;
 
 extern const unsigned char cmd_lengths[256];
 
-int do_cmd_list(uint32_t *list, int count, int *last_cmd);
+int do_cmd_list(uint32_t *list, int count, int *cycles, int *last_cmd);
 
 struct rearmed_cbs;
 

--- a/gpulib/gpu_timing.h
+++ b/gpulib/gpu_timing.h
@@ -1,0 +1,15 @@
+
+// very conservative and wrong
+#define gput_fill(w, h)     (23 + (4 + (w) / 16u) * (h))
+#define gput_copy(w, h)     ((w) * (h))
+#define gput_poly_base()    (23)
+#define gput_poly_base_t()  (gput_poly_base() + 90)
+#define gput_poly_base_g()  (gput_poly_base() + 144)
+#define gput_poly_base_gt() (gput_poly_base() + 225)
+#define gput_quad_base()    gput_poly_base()
+#define gput_quad_base_t()  gput_poly_base_t()
+#define gput_quad_base_g()  gput_poly_base_g()
+#define gput_quad_base_gt() gput_poly_base_gt()
+#define gput_line(k)        (8 + (k))
+#define gput_sprite(w, h)   (8 + ((w) / 2u) * (h))
+

--- a/gpulib/gpulib.c
+++ b/gpulib/gpulib.c
@@ -14,6 +14,7 @@
 #include <stdlib.h> /* for calloc */
 
 #include "gpu.h"
+#include "gpu_timing.h"
 #include "../gpu.h" // meh
 #include "../SoftGPU/externals.h"
 #include "../Gamecube/wiiSXconfig.h"
@@ -37,15 +38,16 @@ int            iFakePrimBusy = 0;
 
 struct psx_gpu gpu;
 
-static noinline int do_cmd_buffer(uint32_t *data, int count);
+static noinline int do_cmd_buffer(uint32_t *data, int count, int *cpu_cycles);
 static void finish_vram_transfer(int is_read);
 
 static noinline void do_cmd_reset(void)
 {
   renderer_sync();
 
+  int dummy = 0;
   if (unlikely(gpu.cmd_len > 0))
-    do_cmd_buffer(gpu.cmd_buffer, gpu.cmd_len);
+    do_cmd_buffer(gpu.cmd_buffer, gpu.cmd_len, &dummy);
   gpu.cmd_len = 0;
 
   if (unlikely(gpu.dma.h > 0))
@@ -176,8 +178,8 @@ static noinline void decide_frameskip(void)
     gpu.frameskip.active = 0;
 
   if (!gpu.frameskip.active && gpu.frameskip.pending_fill[0] != 0) {
-    int dummy;
-    do_cmd_list(gpu.frameskip.pending_fill, 3, &dummy);
+    int dummy = 0;
+    do_cmd_list(gpu.frameskip.pending_fill, 3, &dummy, &dummy);
     gpu.frameskip.pending_fill[0] = 0;
   }
 }
@@ -505,7 +507,7 @@ static void finish_vram_transfer(int is_read)
     gpu.gpu_state_change(PGS_VRAM_TRANSFER_END);
 }
 
-static void do_vram_copy(const uint32_t *params)
+static void do_vram_copy(const uint32_t *params, int *cpu_cycles)
 {
   const uint32_t sx =  GETLE32(&params[0]) & 0x3FF;
   const uint32_t sy = (GETLE32(&params[0]) >> 16) & 0x1FF;
@@ -517,6 +519,7 @@ static void do_vram_copy(const uint32_t *params)
   uint16_t lbuf[128];
   uint32_t x, y;
 
+  *cpu_cycles += gput_copy(w, h);
   if (sx == dx && sy == dy && msb == 0)
     return;
 
@@ -552,7 +555,7 @@ static void do_vram_copy(const uint32_t *params)
 
 static noinline int do_cmd_list_skip(uint32_t *data, int count, int *last_cmd)
 {
-  int cmd = 0, pos = 0, len, dummy, v;
+  int cmd = 0, pos = 0, len, dummy = 0, v;
   int skip = 1;
 
   gpu.frameskip.pending_fill[0] = 0;
@@ -566,7 +569,7 @@ static noinline int do_cmd_list_skip(uint32_t *data, int count, int *last_cmd)
       case 0x02:
         if ((GETLE32(&list[2]) & 0x3ff) > gpu.screen.w || ((GETLE32(&list[2]) >> 16) & 0x1ff) > gpu.screen.h)
           // clearing something large, don't skip
-          do_cmd_list(list, 3, &dummy);
+          do_cmd_list(list, 3, &dummy, &dummy);
         else
           memcpy(gpu.frameskip.pending_fill, list, 3 * 4);
         break;
@@ -616,7 +619,7 @@ static noinline int do_cmd_list_skip(uint32_t *data, int count, int *last_cmd)
   return pos;
 }
 
-static noinline int do_cmd_buffer(uint32_t *data, int count)
+static noinline int do_cmd_buffer(uint32_t *data, int count, int *cpu_cycles)
 {
   int cmd, pos;
   uint32_t old_e3 = gpu.ex_regs[3];
@@ -650,7 +653,7 @@ static noinline int do_cmd_buffer(uint32_t *data, int count)
         cmd = -1; // incomplete cmd, can't consume yet
         break;
       }
-      do_vram_copy(data + pos + 1);
+      do_vram_copy(data + pos + 1, cpu_cycles);
       vram_dirty = 1;
       pos += 4;
       continue;
@@ -660,7 +663,7 @@ static noinline int do_cmd_buffer(uint32_t *data, int count)
     if (gpu.frameskip.active && (gpu.frameskip.allow || ((GETLE32(&data[pos]) >> 24) & 0xf0) == 0xe0))
       pos += do_cmd_list_skip(data + pos, count - pos, &cmd);
     else {
-      pos += do_cmd_list(data + pos, count - pos, &cmd);
+      pos += do_cmd_list(data + pos, count - pos, cpu_cycles, &cmd);
       vram_dirty = 1;
     }
 
@@ -683,7 +686,8 @@ static noinline int do_cmd_buffer(uint32_t *data, int count)
 
 static noinline void flush_cmd_buffer(void)
 {
-  int left = do_cmd_buffer(gpu.cmd_buffer, gpu.cmd_len);
+  int dummy = 0, left;
+  left = do_cmd_buffer(gpu.cmd_buffer, gpu.cmd_len, &dummy);
   if (left > 0)
     memmove(gpu.cmd_buffer, gpu.cmd_buffer + gpu.cmd_len - left, left * 4);
   if (left != gpu.cmd_len) {
@@ -695,7 +699,7 @@ static noinline void flush_cmd_buffer(void)
 
 void LIB_GPUwriteDataMem(uint32_t *mem, int count)
 {
-  int left;
+  int dummy = 0, left;
 
   log_io("gpu_dma_write %p %d\n", mem, count);
 
@@ -704,7 +708,7 @@ void LIB_GPUwriteDataMem(uint32_t *mem, int count)
     flush_cmd_buffer();
   }
 
-  left = do_cmd_buffer(mem, count);
+  left = do_cmd_buffer(mem, count, &dummy);
   if (left)
     log_anomaly("GPUwriteDataMem: discarded %d/%d words\n", left, count);
 }
@@ -721,7 +725,7 @@ long LIB_GPUdmaChain(uint32_t *rambase, uint32_t start_addr, uint32_t *progress_
 {
   uint32_t addr, *list, ld_addr = 0;
   int len, left, count;
-  long cpu_cycles = 0;
+  int cpu_cycles = 0;
 
   preload(rambase + (start_addr & 0x1fffff) / 4);
 
@@ -755,7 +759,7 @@ long LIB_GPUdmaChain(uint32_t *rambase, uint32_t start_addr, uint32_t *progress_
     }
 
     if (len) {
-      left = do_cmd_buffer(list + 1, len);
+      left = do_cmd_buffer(list + 1, len, &cpu_cycles);
       if (left) {
         memcpy(gpu.cmd_buffer, list + 1 + len - left, left * 4);
         gpu.cmd_len = left;


### PR DESCRIPTION
Changes added here:

- **[gpu: start doing some basic gpu timing (notaz)](https://github.com/notaz/pcsx_rearmed/commit/90ac6fed274c1d573a971c66f8a1338e8918f066)**. This adds a task for check and see the basic GPU timing on the emulated games. Minimum only for now, mostly based on Mednafen (Beetle PSX). Applied to GPUlib and SoftGPU (it seems uses the same as DFXVideo?) Fixes some games such Anna Kournikova's Smash Court Tennis (https://github.com/libretro/pcsx_rearmed/issues/783) and Point Blank 1 (https://github.com/libretro/pcsx_rearmed/issues/573).
- **[cdrom: always error out on shell open (notaz)](https://github.com/libretro/pcsx_rearmed/commit/801a96256f5a96470cc99be6ad15e0037136d41c)**. DuckStation (the most accurate PS1 emulator for PC) claims it has been verified on real, actual PSX console hardware. Fixes disc swapping in the game Arc the Lad III. https://github.com/libretro/pcsx_rearmed/issues/804