### PR TITLE
gpu: adjust timing (notaz)

### DIFF
--- a/gpulib/gpu_timing.h
+++ b/gpulib/gpu_timing.h
@@ -1,6 +1,6 @@
 
 // very conservative and wrong
-#define gput_fill(w, h)     (23 + (4 + (w) / 16u) * (h))
+#define gput_fill(w, h)     (23 + (4 + (w) / 32u) * (h))
 #define gput_copy(w, h)     ((w) * (h))
 #define gput_poly_base()    (23)
 #define gput_poly_base_t()  (gput_poly_base() + 90)


### PR DESCRIPTION
seemed to be causing races, likely because we run the CPU too fast.

Fixes https://github.com/notaz/pcsx_rearmed/issues/330

Reference: https://github.com/libretro/pcsx_rearmed/commit/963f41620dce6ddb2527b7e3dced09564031f783