### PR TITLE
gpu: rework DMA vs busy timing, add more GPU slow linked list processing hacks. (notaz)

### DIFF
--- a/SoftGPU/gpulib_if.c
+++ b/SoftGPU/gpulib_if.c
@@ -284,12 +284,13 @@ void renderer_notify_scanout_x_change(int x, int w)
 #include "../gpulib/gpu_timing.h"
 extern const unsigned char cmd_lengths[256];
 
-int do_cmd_list(uint32_t *list, int list_len, int *cpu_cycles_out, int *last_cmd)
+int do_cmd_list(uint32_t *list, int list_len,
+ int *cycles_sum_out, int *cycles_last, int *last_cmd)
 {
+  int cpu_cycles_sum = 0, cpu_cycles = *cycles_last;
   unsigned int cmd = 0, len;
   uint32_t *list_start = list;
   uint32_t *list_end = list + list_len;
-  u32 cpu_cycles = 0;
 
   for (; list < list_end; list += 1 + len)
   {
@@ -319,7 +320,7 @@ int do_cmd_list(uint32_t *list, int list_len, int *cpu_cycles_out, int *last_cmd
 
         while(1)
         {
-          cpu_cycles += gput_line(0);
+          gput_sum(cpu_cycles_sum, cpu_cycles, gput_line(0));
 
           if(list_position >= list_end) {
             cmd = -1;
@@ -344,7 +345,7 @@ int do_cmd_list(uint32_t *list, int list_len, int *cpu_cycles_out, int *last_cmd
 
         while(1)
         {
-          cpu_cycles += gput_line(0);
+          gput_sum(cpu_cycles_sum, cpu_cycles, gput_line(0));
 
           if(list_position >= list_end) {
             cmd = -1;
@@ -365,8 +366,8 @@ int do_cmd_list(uint32_t *list, int list_len, int *cpu_cycles_out, int *last_cmd
 #ifdef TEST
       case 0xA0:          //  sys -> vid
       {
-        u32 load_width = SWAP32(slist[4]);
-        u32 load_height = SWAP32(slist[5]);
+        u32 load_width = LE2HOST16(slist[4]);
+        u32 load_height = LE2HOST16(slist[5]);
         u32 load_size = load_width * load_height;
 
         len += load_size / 2;
@@ -376,32 +377,32 @@ int do_cmd_list(uint32_t *list, int list_len, int *cpu_cycles_out, int *last_cmd
 
       // timing
       case 0x02:
-        cpu_cycles += gput_fill(LE2HOST32(slist[4]) & 0x3ff,
-            LE2HOST32(slist[5]) & 0x1ff);
+        gput_sum(cpu_cycles_sum, cpu_cycles,
+            gput_fill(LE2HOST16(slist[4]) & 0x3ff, LE2HOST16(slist[5]) & 0x1ff));
         break;
-      case 0x20 ... 0x23: cpu_cycles += gput_poly_base();    break;
-      case 0x24 ... 0x27: cpu_cycles += gput_poly_base_t();  break;
-      case 0x28 ... 0x2B: cpu_cycles += gput_quad_base();    break;
-      case 0x2C ... 0x2F: cpu_cycles += gput_quad_base_t();  break;
-      case 0x30 ... 0x33: cpu_cycles += gput_poly_base_g();  break;
-      case 0x34 ... 0x37: cpu_cycles += gput_poly_base_gt(); break;
-      case 0x38 ... 0x3B: cpu_cycles += gput_quad_base_g();  break;
-      case 0x3C ... 0x3F: cpu_cycles += gput_quad_base_gt(); break;
-      case 0x40 ... 0x47: cpu_cycles += gput_line(0);        break;
-      case 0x50 ... 0x57: cpu_cycles += gput_line(0);        break;
+      case 0x20 ... 0x23: gput_sum(cpu_cycles_sum, cpu_cycles, gput_poly_base());    break;
+      case 0x24 ... 0x27: gput_sum(cpu_cycles_sum, cpu_cycles, gput_poly_base_t());  break;
+      case 0x28 ... 0x2B: gput_sum(cpu_cycles_sum, cpu_cycles, gput_quad_base());    break;
+      case 0x2C ... 0x2F: gput_sum(cpu_cycles_sum, cpu_cycles, gput_quad_base_t());  break;
+      case 0x30 ... 0x33: gput_sum(cpu_cycles_sum, cpu_cycles, gput_poly_base_g());  break;
+      case 0x34 ... 0x37: gput_sum(cpu_cycles_sum, cpu_cycles, gput_poly_base_gt()); break;
+      case 0x38 ... 0x3B: gput_sum(cpu_cycles_sum, cpu_cycles, gput_quad_base_g());  break;
+      case 0x3C ... 0x3F: gput_sum(cpu_cycles_sum, cpu_cycles, gput_quad_base_gt()); break;
+      case 0x40 ... 0x47: gput_sum(cpu_cycles_sum, cpu_cycles, gput_line(0));        break;
+      case 0x50 ... 0x57: gput_sum(cpu_cycles_sum, cpu_cycles, gput_line(0));        break;
       case 0x60 ... 0x63:
-        cpu_cycles += gput_sprite(LE2HOST32(slist[4]) & 0x3ff,
-            LE2HOST32(slist[5]) & 0x1ff);
+        gput_sum(cpu_cycles_sum, cpu_cycles,
+            gput_sprite(LE2HOST16(slist[4]) & 0x3ff, LE2HOST16(slist[5]) & 0x1ff));
         break;
       case 0x64 ... 0x67:
-        cpu_cycles += gput_sprite(LE2HOST32(slist[6]) & 0x3ff,
-            LE2HOST32(slist[7]) & 0x1ff);
+        gput_sum(cpu_cycles_sum, cpu_cycles,
+            gput_sprite(LE2HOST16(slist[6]) & 0x3ff, LE2HOST16(slist[7]) & 0x1ff));
         break;
-      case 0x68 ... 0x6B: cpu_cycles += gput_sprite(1, 1);   break;
+      case 0x68 ... 0x6B: gput_sum(cpu_cycles_sum, cpu_cycles, gput_sprite(1, 1));   break;
       case 0x70 ... 0x73:
-      case 0x74 ... 0x77: cpu_cycles += gput_sprite(8, 8);   break;
+      case 0x74 ... 0x77: gput_sum(cpu_cycles_sum, cpu_cycles, gput_sprite(8, 8));   break;
       case 0x78 ... 0x7B:
-      case 0x7C ... 0x7F: cpu_cycles += gput_sprite(16, 16); break;
+      case 0x7C ... 0x7F: gput_sum(cpu_cycles_sum, cpu_cycles, gput_sprite(16, 16)); break;
     }
   }
 
@@ -409,7 +410,8 @@ breakloop:
   gpu.ex_regs[1] &= ~0x1ff;
   gpu.ex_regs[1] |= lGPUstatusRet & 0x1ff;
 
-  *cpu_cycles_out += cpu_cycles;
+  *cycles_sum_out += cpu_cycles_sum;
+  *cycles_last = cpu_cycles;
   *last_cmd = cmd;
   return list - list_start;
 }

--- a/database.c
+++ b/database.c
@@ -30,6 +30,8 @@ static const char * const gpu_slow_llist_db[] =
 	"SCES02834", "SCUS94570", "SCUS94616", "SCUS94654",
 	/* Final Fantasy IV */
 	"SCES03840", "SLPM86028", "SLUS01360",
+	/* Point Blank - calibration cursor */
+	"SCED00287", "SCES00886", "SLUS00481",
 	/* Simple 1500 Series Vol. 57: The Meiro */
 	"SLPM86715",
 	/* Spot Goes to Hollywood */

--- a/gpulib/gpu.h
+++ b/gpulib/gpu.h
@@ -164,7 +164,8 @@ extern struct psx_gpu gpu;
 
 extern const unsigned char cmd_lengths[256];
 
-int do_cmd_list(uint32_t *list, int count, int *cycles, int *last_cmd);
+int do_cmd_list(uint32_t *list, int count,
+	int *cycles_sum, int *cycles_last, int *last_cmd);
 
 struct rearmed_cbs;
 
@@ -192,7 +193,8 @@ struct GPUFreeze;
 long LIB_GPUinit(void);
 long LIB_GPUshutdown(void);
 void LIB_GPUwriteDataMem(uint32_t *mem, int count);
-long LIB_GPUdmaChain(uint32_t *rambase, uint32_t addr, uint32_t *progress_addr);
+long LIB_GPUdmaChain(uint32_t *rambase, uint32_t addr,
+		uint32_t *progress_addr, int32_t *cycles_last_cmd);
 void LIB_GPUwriteData(uint32_t data);
 void LIB_GPUreadDataMem(uint32_t *mem, int count);
 uint32_t LIB_GPUreadData(void);

--- a/gpulib/gpu_timing.h
+++ b/gpulib/gpu_timing.h
@@ -1,6 +1,6 @@
 
 // very conservative and wrong
-#define gput_fill(w, h)     (23 + (4 + (w) / 32u) * (h))
+#define gput_fill(w, h)     (23 + (4 + (w) / 16u) * (h))
 #define gput_copy(w, h)     ((w) * (h))
 #define gput_poly_base()    (23)
 #define gput_poly_base_t()  (gput_poly_base() + 90)
@@ -13,3 +13,7 @@
 #define gput_line(k)        (8 + (k))
 #define gput_sprite(w, h)   (8 + ((w) / 2u) * (h))
 
+// sort of a workaround for lack of proper fifo emulation
+#define gput_sum(sum, cnt, new_cycles) do { \
+  sum += cnt; cnt = new_cycles; \
+} while (0)

--- a/gpulib/gpulib.c
+++ b/gpulib/gpulib.c
@@ -38,7 +38,8 @@ int            iFakePrimBusy = 0;
 
 struct psx_gpu gpu;
 
-static noinline int do_cmd_buffer(uint32_t *data, int count, int *cpu_cycles);
+static noinline int do_cmd_buffer(uint32_t *data, int count,
+    int *cycles_sum, int *cycles_last);
 static void finish_vram_transfer(int is_read);
 
 static noinline void do_cmd_reset(void)
@@ -47,7 +48,7 @@ static noinline void do_cmd_reset(void)
 
   int dummy = 0;
   if (unlikely(gpu.cmd_len > 0))
-    do_cmd_buffer(gpu.cmd_buffer, gpu.cmd_len, &dummy);
+    do_cmd_buffer(gpu.cmd_buffer, gpu.cmd_len, &dummy, &dummy);
   gpu.cmd_len = 0;
 
   if (unlikely(gpu.dma.h > 0))
@@ -179,7 +180,7 @@ static noinline void decide_frameskip(void)
 
   if (!gpu.frameskip.active && gpu.frameskip.pending_fill[0] != 0) {
     int dummy = 0;
-    do_cmd_list(gpu.frameskip.pending_fill, 3, &dummy, &dummy);
+    do_cmd_list(gpu.frameskip.pending_fill, 3, &dummy, &dummy, &dummy);
     gpu.frameskip.pending_fill[0] = 0;
   }
 }
@@ -577,7 +578,7 @@ static noinline int do_cmd_list_skip(uint32_t *data, int count, int *last_cmd)
       case 0x02:
         if ((GETLE32(&list[2]) & 0x3ff) > gpu.screen.w || ((GETLE32(&list[2]) >> 16) & 0x1ff) > gpu.screen.h)
           // clearing something large, don't skip
-          do_cmd_list(list, 3, &dummy, &dummy);
+          do_cmd_list(list, 3, &dummy, &dummy, &dummy);
         else
           memcpy(gpu.frameskip.pending_fill, list, 3 * 4);
         break;
@@ -627,7 +628,8 @@ static noinline int do_cmd_list_skip(uint32_t *data, int count, int *last_cmd)
   return pos;
 }
 
-static noinline int do_cmd_buffer(uint32_t *data, int count, int *cpu_cycles)
+static noinline int do_cmd_buffer(uint32_t *data, int count,
+    int *cycles_sum, int *cycles_last)
 {
   int cmd, pos;
   uint32_t old_e3 = gpu.ex_regs[3];
@@ -661,7 +663,9 @@ static noinline int do_cmd_buffer(uint32_t *data, int count, int *cpu_cycles)
         cmd = -1; // incomplete cmd, can't consume yet
         break;
       }
-      do_vram_copy(data + pos + 1, cpu_cycles);
+      *cycles_sum += *cycles_last;
+      *cycles_last = 0;
+      do_vram_copy(data + pos + 1, cycles_last);
       vram_dirty = 1;
       pos += 4;
       continue;
@@ -676,7 +680,7 @@ static noinline int do_cmd_buffer(uint32_t *data, int count, int *cpu_cycles)
     if (gpu.frameskip.active && (gpu.frameskip.allow || ((GETLE32(&data[pos]) >> 24) & 0xf0) == 0xe0))
       pos += do_cmd_list_skip(data + pos, count - pos, &cmd);
     else {
-      pos += do_cmd_list(data + pos, count - pos, cpu_cycles, &cmd);
+      pos += do_cmd_list(data + pos, count - pos, cycles_sum, cycles_last, &cmd);
       vram_dirty = 1;
     }
 
@@ -700,7 +704,7 @@ static noinline int do_cmd_buffer(uint32_t *data, int count, int *cpu_cycles)
 static noinline void flush_cmd_buffer(void)
 {
   int dummy = 0, left;
-  left = do_cmd_buffer(gpu.cmd_buffer, gpu.cmd_len, &dummy);
+  left = do_cmd_buffer(gpu.cmd_buffer, gpu.cmd_len, &dummy, &dummy);
   if (left > 0)
     memmove(gpu.cmd_buffer, gpu.cmd_buffer + gpu.cmd_len - left, left * 4);
   if (left != gpu.cmd_len) {
@@ -721,7 +725,7 @@ void LIB_GPUwriteDataMem(uint32_t *mem, int count)
     flush_cmd_buffer();
   }
 
-  left = do_cmd_buffer(mem, count, &dummy);
+  left = do_cmd_buffer(mem, count, &dummy, &dummy);
   if (left)
     log_anomaly("GPUwriteDataMem: discarded %d/%d words\n", left, count);
 }
@@ -734,11 +738,13 @@ void LIB_GPUwriteData(uint32_t data)
     flush_cmd_buffer();
 }
 
-long LIB_GPUdmaChain(uint32_t *rambase, uint32_t start_addr, uint32_t *progress_addr)
+long LIB_GPUdmaChain(uint32_t *rambase, uint32_t start_addr,
+  uint32_t *progress_addr, int32_t *cycles_last_cmd)
 {
   uint32_t addr, *list, ld_addr = 0;
   int len, left, count;
-  int cpu_cycles = 0;
+  int cpu_cycles_sum = 0;
+  int cpu_cycles_last = 0;
 
   preload(rambase + (start_addr & 0x1fffff) / 4);
 
@@ -754,12 +760,12 @@ long LIB_GPUdmaChain(uint32_t *rambase, uint32_t start_addr, uint32_t *progress_
     addr = GETLE32(&list[0]) & 0xffffff;
     preload(rambase + (addr & 0x1fffff) / 4);
 
-    cpu_cycles += 10;
+    cpu_cycles_sum += 10;
     if (len > 0)
-      cpu_cycles += 5 + len;
+      cpu_cycles_sum += 5 + len;
 
-    log_io(".chain %08lx #%d+%d %u\n",
-      (long)(list - rambase) * 4, len, gpu.cmd_len, cpu_cycles);
+    log_io(".chain %08lx #%d+%d %u+%u\n",
+      (long)(list - rambase) * 4, len, gpu.cmd_len, cpu_cycles_sum, cpu_cycles_last);
     if (unlikely(gpu.cmd_len > 0)) {
       if (gpu.cmd_len + len > ARRAY_SIZE(gpu.cmd_buffer)) {
         log_anomaly("cmd_buffer overflow, likely garbage commands\n");
@@ -772,7 +778,7 @@ long LIB_GPUdmaChain(uint32_t *rambase, uint32_t start_addr, uint32_t *progress_
     }
 
     if (len) {
-      left = do_cmd_buffer(list + 1, len, &cpu_cycles);
+      left = do_cmd_buffer(list + 1, len, &cpu_cycles_sum, &cpu_cycles_last);
       if (left) {
         memcpy(gpu.cmd_buffer, list + 1 + len - left, left * 4);
         gpu.cmd_len = left;
@@ -809,12 +815,14 @@ long LIB_GPUdmaChain(uint32_t *rambase, uint32_t start_addr, uint32_t *progress_
     }
   }
 
+  //printf(" -> %d %d\n", cpu_cycles_sum, cpu_cycles_last);
   gpu.state.last_list.frame = *gpu.state.frame_count;
   gpu.state.last_list.hcnt = *gpu.state.hcnt;
-  gpu.state.last_list.cycles = cpu_cycles;
+  gpu.state.last_list.cycles = cpu_cycles_sum + cpu_cycles_last;
   gpu.state.last_list.addr = start_addr;
 
-  return cpu_cycles;
+  *cycles_last_cmd = cpu_cycles_last;
+  return cpu_cycles_sum;
 }
 
 void LIB_GPUreadDataMem(uint32_t *mem, int count)

--- a/plugins.h
+++ b/plugins.h
@@ -61,7 +61,7 @@ typedef void (CALLBACK* GPUwriteDataMem)(uint32_t *, int);
 typedef uint32_t (CALLBACK* GPUreadStatus)(void);
 typedef uint32_t (CALLBACK* GPUreadData)(void);
 typedef void (CALLBACK* GPUreadDataMem)(uint32_t *, int);
-typedef long (CALLBACK* GPUdmaChain)(uint32_t *,uint32_t, uint32_t *);
+typedef long (CALLBACK* GPUdmaChain)(uint32_t *, uint32_t, uint32_t *, int32_t *);
 typedef void (CALLBACK* GPUupdateLace)(void);
 typedef void (CALLBACK* GPUmakeSnapshot)(void);
 typedef void (CALLBACK* GPUkeypressed)(int);

--- a/psxdma.c
+++ b/psxdma.c
@@ -93,6 +93,7 @@ void psxDma4(u32 madr, u32 bcr, u32 chcr) { // SPU
 	DMA_INTERRUPT(4);
 }
 
+#if 0
 // Taken from PEOPS SOFTGPU
 static inline bool CheckForEndlessLoop(u32 laddr, u32 *lUsedAddr) {
 	if (laddr == lUsedAddr[1]) return TRUE;
@@ -133,11 +134,12 @@ static u32 gpuDmaChainSize(u32 addr) {
 
 	return size;
 }
+#endif
 
 void psxDma2(u32 madr, u32 bcr, u32 chcr) { // GPU
-	u32 *ptr, madr_next, *madr_next_p, size;
+	u32 *ptr, madr_next, *madr_next_p;
 	u32 words, words_left, words_max, words_copy;
-	int do_walking;
+	int cycles_sum, cycles_last_cmd = 0, do_walking;
 
 	madr &= ~3;
 	switch (chcr) {
@@ -198,18 +200,19 @@ void psxDma2(u32 madr, u32 bcr, u32 chcr) { // GPU
 			do_walking = Config.hacks.gpu_slow_list_walking;
 			madr_next_p = do_walking ? &madr_next : NULL;
 
-			size = GPU_dmaChain((u32 *)psxM, madr & 0x1fffff, madr_next_p);
-			if ((int)size <= 0)
-				size = gpuDmaChainSize(madr);
+			cycles_sum = GPU_dmaChain((u32 *)psxM, madr & 0x1fffff,
+					madr_next_p, &cycles_last_cmd);
 
 			HW_DMA2_MADR = SWAPu32(madr_next);
 
 			// a hack for Judge Dredd which is annoyingly sensitive to timing
 			if (Config.hacks.gpu_timing1024)
-				size = 1024;
+				cycles_sum = 1024;
 
-			psxRegs.gpuIdleAfter = psxRegs.cycle + size + 16;
-			set_event(PSXINT_GPUDMA, size);
+			psxRegs.gpuIdleAfter = psxRegs.cycle + cycles_sum + cycles_last_cmd;
+			set_event(PSXINT_GPUDMA, cycles_sum);
+			//printf("%u dma2cf: %d,%d %08x\n", psxRegs.cycle, cycles_sum,
+			//	cycles_last_cmd, HW_DMA2_MADR);
 			return;
 
 		default:
@@ -224,11 +227,17 @@ void psxDma2(u32 madr, u32 bcr, u32 chcr) { // GPU
 void gpuInterrupt() {
 	if (HW_DMA2_CHCR == SWAP32(0x01000401) && !(HW_DMA2_MADR & SWAP32(0x800000)))
 	{
-		u32 size, madr_next = 0xffffff, madr = SWAPu32(HW_DMA2_MADR);
-		size = GPU_dmaChain((u32 *)psxM, madr & 0x1fffff, &madr_next);
+		u32 madr_next = 0xffffff, madr = SWAPu32(HW_DMA2_MADR);
+		int cycles_sum, cycles_last_cmd = 0;
+		cycles_sum = GPU_dmaChain((u32 *)psxM, madr & 0x1fffff,
+				&madr_next, &cycles_last_cmd);
 		HW_DMA2_MADR = SWAPu32(madr_next);
-		psxRegs.gpuIdleAfter = psxRegs.cycle + size + 64;
-		set_event(PSXINT_GPUDMA, size);
+		if ((s32)(psxRegs.gpuIdleAfter - psxRegs.cycle) > 0)
+			cycles_sum += psxRegs.gpuIdleAfter - psxRegs.cycle;
+		psxRegs.gpuIdleAfter = psxRegs.cycle + cycles_sum + cycles_last_cmd;
+		set_event(PSXINT_GPUDMA, cycles_sum);
+		//printf("%u dma2cn: %d,%d %08x\n", psxRegs.cycle, cycles_sum,
+		//	cycles_last_cmd, HW_DMA2_MADR);
 		return;
 	}
 	if (HW_DMA2_CHCR & SWAP32(0x01000000))


### PR DESCRIPTION
notaz says that maybe he/she should implement actual FIFO emulation instead someday, but for now this works for fix graphical issues in some games (ex. **CTR: Crash Team Racing**).

Workaround for https://github.com/libretro/pcsx_rearmed/issues/809

Also adds the game **Point Blank** to the GPU Slow linked list processing hack for fix an issue with the calibration cursor.

This was based in the commits https://github.com/notaz/pcsx_rearmed/commit/8412166f53abb220b85e0aff47924c04724abfa4 and https://github.com/libretro/pcsx_rearmed/commit/d28e9a2e861c7a4cf6cacd244e3279628fff66d9.