### PR TITLE
gpulib: maybe better loop detection (notaz)

### DIFF
--- a/gpulib/gpulib.c
+++ b/gpulib/gpulib.c
@@ -741,8 +741,8 @@ void LIB_GPUwriteData(uint32_t data)
 long LIB_GPUdmaChain(uint32_t *rambase, uint32_t start_addr,
   uint32_t *progress_addr, int32_t *cycles_last_cmd)
 {
-  uint32_t addr, *list, ld_addr = 0;
-  int len, left, count;
+  uint32_t addr, *list, ld_addr;
+  int len, left, count, ld_count = 32;
   int cpu_cycles_sum = 0;
   int cpu_cycles_last = 0;
 
@@ -752,7 +752,7 @@ long LIB_GPUdmaChain(uint32_t *rambase, uint32_t start_addr,
     flush_cmd_buffer();
 
   log_io("gpu_dma_chain\n");
-  addr = start_addr & 0xffffff;
+  addr = ld_addr = start_addr & 0xffffff;
   for (count = 0; (addr & 0x800000) == 0; count++)
   {
     list = rambase + (addr & 0x1fffff) / 4;
@@ -790,28 +790,13 @@ long LIB_GPUdmaChain(uint32_t *rambase, uint32_t start_addr,
       *progress_addr = addr;
       break;
     }
-    #define LD_THRESHOLD (8*1024)
-    if (count >= LD_THRESHOLD) {
-      if (count == LD_THRESHOLD) {
-        ld_addr = addr;
-        continue;
-      }
-
-      // loop detection marker
-      // (bit23 set causes DMA error on real machine, so
-      //  unlikely to be ever set by the game)
-      list[0] |= SWAP32_C(0x800000);
+    if (addr == ld_addr) {
+      log_anomaly("GPUdmaChain: loop @ %08x, cnt=%u\n", addr, count);
+      break;
     }
-  }
-
-  if (ld_addr != 0) {
-    // remove loop detection markers
-    count -= LD_THRESHOLD + 2;
-    addr = ld_addr & 0x1fffff;
-    while (count-- > 0) {
-      list = rambase + addr / 4;
-      addr = GETLE32(&list[0]) & 0x1fffff;
-      list[0] &= SWAP32_C(~0x800000);
+    if (count == ld_count) {
+      ld_addr = addr;
+      ld_count *= 2;
     }
   }
 


### PR DESCRIPTION
Note that this thing isn't needed at all with gpu_slow_llists (GPU Slow linked list processing hack) enabled.

Fix for crash at Loading screens in This is Football 2. https://github.com/libretro/pcsx_rearmed/issues/812
Fixes https://github.com/xjsxjs197/WiiSXRX_2022/issues/180.

Reference: https://github.com/libretro/pcsx_rearmed/commit/2048ae31f9e75c105cdf60e572ca4bc3816bbe84