### PR TITLE
Add missing cdrIsoMultidiskSelect command to Swap CD code from PCSX-ReARMed.

### DIFF
--- a/Gamecube/GamecubeMain.cpp
+++ b/Gamecube/GamecubeMain.cpp
@@ -770,6 +770,7 @@ int loadISOSwap(fileBrowser_file* file) {
 
 	memcpy(&isoFile, file, sizeof(fileBrowser_file) );
 
+    cdrIsoMultidiskSelect++;
     CdromId[0] = '\0';
     CdromLabel[0] = '\0';
 	


### PR DESCRIPTION
Adds the missing command `cdrIsoMultidiskSelect++` to the **Swap CD (Multi-disk) command/logic**.

SBI detection logics also depends of this command/variable, and Libretro PCSX-ReARMed has this command.

Possible fix for issue https://github.com/xjsxjs197/WiiSXRX_2022/issues/96.

Reference: https://github.com/libretro/pcsx_rearmed/blob/master/frontend/menu.c#L2271