### PR TITLE
Update version in Credits screen from v2.4 to v3.0

### DIFF
--- a/Gamecube/menu/MainFrame.cpp
+++ b/Gamecube/menu/MainFrame.cpp
@@ -167,9 +167,9 @@ void Func_Credits()
 {
 	char CreditsInfo[512] = "";
 #ifdef HW_RVL
-	sprintf(CreditsInfo,"WiiStation 2.4\n");
+	sprintf(CreditsInfo,"WiiStation 3.0\n");
 #else
-	sprintf(CreditsInfo,"CubeStation 2.4\n");
+	sprintf(CreditsInfo,"CubeStation 3.0\n");
 #endif
 	strcat(CreditsInfo,"www.github.com/xjsxjs197/WiiSXRX_2022\n");
 	strcat(CreditsInfo,"WiiStation: xjsxjs197 - Icon: Dakangel\n");


### PR DESCRIPTION
Forgot to update that version in the Credits screen.

A small advice: every time you change (update) the version number on future release, don't forget to change the version number of WiiStation in the Credits screen.
For do this, go to the file **Gamecube/menu/MainFrame.cpp**, go to **line 170** and put the new version number replacing the old one, like as i did here.
Do the same thing in the **line 172**.