### PR TITLE
psxhw: adjust sio stat (notaz)

### DIFF
--- a/psxhw.c
+++ b/psxhw.c
@@ -116,6 +116,12 @@ u32 psxHwReadGpuSR(void)
     return v;
 }
 
+u32 sio1ReadStat16(void)
+{
+	// Armored Core, F1 Link cable misdetection
+	return 0xa0;
+}
+
 // a hack due to poor timing of gpu idle bit
 // to get rid of this, GPU draw times, DMAs, cpu timing has to fall within
 // certain timing window or else games like "ToHeart" softlock
@@ -190,7 +196,7 @@ u16 psxHwRead16(u32 add) {
         case 0x1048: hard = ModeReg; break;
         case 0x104a: hard = CtrlReg; break;
         case 0x104e: hard = BaudReg; break;
-        case 0x1054: hard = 0x80; break; // Armored Core Link cable misdetection
+        case 0x1054: hard = sio1ReadStat16(); break;
         case 0x1100: hard = psxRcntRcount(0); break;
         case 0x1104: hard = psxRcntRmode(0); break;
         case 0x1108: hard = psxRcntRtarget(0); break;

--- a/psxhw.h
+++ b/psxhw.h
@@ -79,6 +79,7 @@ u32  psxHwRead32(u32 add);
 void psxHwWrite8 (u32 add, u32 value);
 void psxHwWrite16(u32 add, u32 value);
 void psxHwWrite32(u32 add, u32 value);
+u32 sio1ReadStat16(void);
 int psxHwFreeze(gzFile f, int Mode);
 
 void psxHwWriteIstat(u32 value);


### PR DESCRIPTION
Fixes Formula 1 freezing at first loading screen.
https://github.com/libretro/pcsx_rearmed/issues/822

Based on https://github.com/libretro/pcsx_rearmed/commit/1546496fa818dc51e763c37f4f2e2456dafa4e13