### PR TITLE
fix Force NTSC option on Old GPU/P.E.Op.S. showing garbage in the bottom of the screen. (Jokippo)

### DIFF
--- a/PeopsSoftGPU/gpu.c
+++ b/PeopsSoftGPU/gpu.c
@@ -682,7 +682,7 @@ void ChangeDispOffsetsY(void)                          // Y CENTER
 
 //
 
- if(PSXDisplay.PAL) iT=48; else iT=28;
+ if(PSXDisplay.PAL || forceNTSC) iT=48; else iT=28;
 
  if(PSXDisplay.Range.y0>=iT)
   {

--- a/gpulib/oldGpu.c
+++ b/gpulib/oldGpu.c
@@ -406,7 +406,7 @@ void ChangeDispOffsetsY(void)                          // Y CENTER
 
 //
 
- if(PSXDisplay.PAL) iT=48; else iT=28;
+ if(PSXDisplay.PAL || forceNTSC) iT=48; else iT=28;
 
  if(PSXDisplay.Range.y0>=iT)
   {


### PR DESCRIPTION
Fixes https://github.com/xjsxjs197/WiiSXRX_2022/issues/236.

This only fixes Force NTSC in Old GPU (the one based on P.E.Op.S.), as the New GPU (GPULIB/DFXVideo) still has resolution(?) strechting issues (will be fixed on https://github.com/xjsxjs197/WiiSXRX_2022/pull/238).

**Before:**
![ff8_ws_oldgpu_badgarbage](https://github.com/xjsxjs197/WiiSXRX_2022/assets/66485640/bf287b35-cc14-4b5b-894e-bfc2b751bc2b)

**After:**
![ff8_ws_oldnewgpu_ok](https://github.com/xjsxjs197/WiiSXRX_2022/assets/66485640/7ff766c9-e393-490c-a463-6383d8750e7e)
