### PR TITLE
fix Force NTSC option on New GPU/GPULIB+DFXVideo being too stretched.

### DIFF
--- a/gpulib/gpulib.c
+++ b/gpulib/gpulib.c
@@ -80,7 +80,7 @@ static noinline void update_width(void)
   static const uint8_t hdivs[8] = { 10, 7, 8, 7, 5, 7, 4, 7 };
   uint8_t hdiv = hdivs[(gpu.status >> 16) & 7];
   int hres = hres_all[(gpu.status >> 16) & 7];
-  int pal = (forceNTSC == FORCENTSC_ENABLE ? 0 : (gpu.status & PSX_GPU_STATUS_PAL));
+  int pal = gpu.status & PSX_GPU_STATUS_PAL;
   int sw = gpu.screen.x2 - gpu.screen.x1;
   int type = gpu.state.screen_centering_type;
   int x = 0, x_auto;
@@ -124,7 +124,7 @@ static noinline void update_width(void)
 
 static noinline void update_height(void)
 {
-  int pal = (forceNTSC == FORCENTSC_ENABLE ? 0 : (gpu.status & PSX_GPU_STATUS_PAL));
+  int pal = gpu.status & PSX_GPU_STATUS_PAL;
   int dheight = gpu.status & PSX_GPU_STATUS_DHEIGHT;
   int y = gpu.screen.y1 - (pal ? 39 : 16); // 39 for spyro
   int sh = gpu.screen.y2 - gpu.screen.y1;


### PR DESCRIPTION
The old GPU (**P.E.Op.S.**) plugin needed to check **forceNTSC** option variable for stretch correctly the screen (see https://github.com/xjsxjs197/WiiSXRX_2022/pull/237) but the new GPU (**gpulib+DFXVideo**) plugin doesn't need to check it, and trying to set it will occur stretching issues...

so let's just delete this need of checking, **as the gpulib is capable to detect if the game uses PAL resolutions, even if forcing the game region to NTSC.**

gpulib only handles the display graphics and resolution, as **CheckPsxType** sets the region framerate the emulated game will have (NTSC @ 60fps/PAL @ 50fps).

For now i will leave in draft, as i will make some users to test my fix.

For your information:

**Before this fix:**
![ff8_ws_newgpu_badstrectched](https://github.com/xjsxjs197/WiiSXRX_2022/assets/66485640/59001a8b-8419-496b-930c-84d8531fd1c5)

**After this fix:**
![ff8_ws_oldnewgpu_ok](https://github.com/xjsxjs197/WiiSXRX_2022/assets/66485640/6828c85d-c230-4ff1-ab60-3743d2666ba0)
