### PR TITLE
Update timing (override) hack for Power Rangers: Lightspeed Rescue (SuperrSonic)

### DIFF
--- a/database.c
+++ b/database.c
@@ -154,8 +154,8 @@ cycle_multiplier_overrides[] =
     /* Digimon World */
     { 153, { "SLUS01032", "SLES02914" } },
     /* on 'new' PPC Dynarec this game works correctly but not on Lightrec nor Interpreter */
-    /* Power Rangers: Lightspeed Rescue - jump does not work with 175 */
-    { 222, { "SLUS01114", "SLES03286" } },
+    /* Power Rangers: Lightspeed Rescue - jumping fails if FPS is over 30 */
+    { 310, { "SLUS01114", "SLES03286" } },
     /* Syphon Filter - reportedly hangs under unknown conditions */
     { 169, { "SCUS94240" } },
     /* Psychic Detective - some weird race condition in the game's cdrom code */


### PR DESCRIPTION
Suggested on https://github.com/SuperrSonic/WiiSX-Titanium/commit/39981630cecc18d40c4f43ae15195858ccd69c30

Original message ([see here](https://github.com/libretro/pcsx_rearmed/issues/837#issuecomment-2189745153)):

> I'm surprised someone else was interested in testing this game, it's one of my favorites. Playing it on an original PS1 I can say that it does happen but not to the same extent as seen in emulators.
> 
> But what's really annoying about this bug is that you can't beat the game because at level 4 it becomes impossible to progress.
> From my tests 222 is too low and the softlock occurs but can be avoided if one tries hard enough... but that sucks.
> 
> So my solution was to use 280, however since this was intended for the Wii port, I found [310](https://github.com/SuperrSonic/WiiSX-Titanium/commit/39981630cecc18d40c4f43ae15195858ccd69c30) ideal to maintain the emulation at full speed, at the cost of the game dropping more frames, this allowed jumping to always work and keep the sound stutter free, as I've tested the entire game this way.
> 
> I compiled a list of playthroughs that show people running into the problematic spot in several emulators, I couldn't find a single one using real hardware, though. They all manage to pass through eventually, but you can definitely tell something's not right.
> https://www.youtube.com/watch?v=WafN_bKnNQA&t=2062s
> https://www.youtube.com/watch?v=0xlH-ogDvqY&t=728s
> https://www.youtube.com/watch?v=Hl9p-m2xYKQ&t=517s
> https://www.youtube.com/watch?v=lyLqWiahTOY&t=1741s