### PR TITLE
fix ZStandard library compilation related to legacy support

### DIFF
--- a/deps/libchdr/deps/zstd-1.5.6/Makefile.wii
+++ b/deps/libchdr/deps/zstd-1.5.6/Makefile.wii
@@ -9,7 +9,7 @@ endif
 
 include $(DEVKITPPC)/wii_rules
 
-INCLUDES := ./ ./common/ ./decompress/
+INCLUDES := ./ ./common/ ./decompress/ ./legacy/
 
 # Directories.
 OBJ_DIR			:= obj/release
@@ -25,7 +25,8 @@ PIPE_TO_SED := 2>&1 | sed "s/:\([0-9]*\):/\(\1\) :/"
 # Library source files.
 SDL_SRCS	:= \
 	$(wildcard $(ZSTDLIB_SRC_DIR)/common/*.c) \
-	$(wildcard $(ZSTDLIB_SRC_DIR)/decompress/*.c)
+	$(wildcard $(ZSTDLIB_SRC_DIR)/decompress/*.c) \
+	$(wildcard $(ZSTDLIB_SRC_DIR)/legacy/*.c)
 
 # Library object files.
 ZSTDLIB_OBJS	:= $(subst $(ZSTDLIB_SRC_DIR),$(ZSTDLIB_OBJ_DIR),$(SDL_SRCS:.c=.o))


### PR DESCRIPTION
if **-DZSTD_LEGACY_SUPPORT=4** is enabled on Makefile and it can't find and/or compile the legacy code, it will result in "no variables defined", resulting in compilation errors.

Add the legacy support code to Makefile, solves this issue and can be compiled normally with **-DZSTD_LEGACY_SUPPORT=4**.

Fixes https://github.com/xjsxjs197/WiiSXRX_2022/pull/253#issuecomment-2249529164