### PR TITLE
Remove support for loading IMG, CCD, SUB files.

### DIFF
--- a/Gamecube/fileBrowser/fileBrowser-libfat.c
+++ b/Gamecube/fileBrowser/fileBrowser-libfat.c
@@ -198,7 +198,8 @@ void InitRemovalThread()
 #endif
 }
 
-static bool isCueCcdFileExist(const char *filePath, const char *fileName, const char *fileType) {
+//static bool isCueCcdFileExist(const char *filePath, const char *fileName, const char *fileType) {
+static bool isCueFileExist(const char *filePath, const char *fileName, const char *fileType) {
     static char cuename[FILE_BROWSER_MAX_PATH_LEN];
     memset(cuename, 0, FILE_BROWSER_MAX_PATH_LEN);
     sprintf(cuename, "%s/%s", filePath, fileName);
@@ -232,8 +233,8 @@ static bool isCueCcdFileExist(const char *filePath, const char *fileName, const 
 static bool isFileOk(const char *filePath, const char *fileName) {
     if (strstr(fileName, ".cue")
         || strstr(fileName, ".CUE")
-        || strstr(fileName, ".ccd")
-        || strstr(fileName, ".CCD")
+//      || strstr(fileName, ".ccd")
+//      || strstr(fileName, ".CCD")
         || strstr(fileName, ".iso")
         || strstr(fileName, ".ISO")
         || strstr(fileName, ".chd")
@@ -241,15 +242,15 @@ static bool isFileOk(const char *filePath, const char *fileName) {
     {
         return true;
     }
-    else if (strstr(fileName, ".sub") || strstr(fileName, ".SUB"))
-    {
-        return false;
-    }
+//  else if (strstr(fileName, ".sub") || strstr(fileName, ".SUB"))
+//  {
+//      return false;
+//  }
     else if (((strstr(fileName, ".bin") || strstr(fileName, ".BIN")) &&
-             (isCueCcdFileExist(filePath, fileName, ".cue") || isCueCcdFileExist(filePath, fileName, ".CUE")))
-             ||
-             ((strstr(fileName, ".img") || strstr(fileName, ".IMG")) &&
-             (isCueCcdFileExist(filePath, fileName, ".ccd") || isCueCcdFileExist(filePath, fileName, ".CCD")))
+             (isCueFileExist(filePath, fileName, ".cue") || isCueFileExist(filePath, fileName, ".CUE")))
+//           ||
+//           ((strstr(fileName, ".img") || strstr(fileName, ".IMG")) &&
+//           (isCueFileExist(filePath, fileName, ".ccd") || isCueFileExist(filePath, fileName, ".CCD")))
              )
     {
         return false;

--- a/cdriso.c
+++ b/cdriso.c
@@ -1403,7 +1403,8 @@ static long CALLBACK ISOopen(void) {
 	// maybe user selected metadata file instead of main .bin ..
 	bin_filename = GetIsoFile();
 	if (ftello(cdHandle) < 2352 * 0x10) {
-		static const char *exts[] = { ".bin", ".BIN", ".img", ".IMG" };
+		//static const char *exts[] = { ".bin", ".BIN", ".img", ".IMG" };
+		static const char *exts[] = { ".bin", ".BIN" };
 		FILE *tmpf = NULL;
 		size_t i;
 		char *p;

--- a/cdriso.c
+++ b/cdriso.c
@@ -477,6 +477,7 @@ static int parsecue(const char *isofile) {
 
 // this function tries to get the .ccd file of the given .img
 // the necessary data is put into the ti (trackinformation)-array
+/*
 static int parseccd(const char *isofile) {
 	char			ccdname[MAXPATHLEN];
 	FILE			*fi;
@@ -533,6 +534,7 @@ static int parseccd(const char *isofile) {
 
 	return 0;
 }
+*/
 
 // this function tries to get the .mds file of the given .mdf
 // the necessary data is put into the ti (trackinformation)-array
@@ -1017,6 +1019,7 @@ fail_io:
 #endif // USE_LIBCHDR
 
 // this function tries to get the .sub file of the given .img
+/*
 static int opensubfile(const char *isoname) {
 	char		subname[MAXPATHLEN];
 
@@ -1037,6 +1040,7 @@ static int opensubfile(const char *isoname) {
 
 	return 0;
 }
+*/
 
 static int opensbifile(const char *isoname) {
 	char		sbiname[MAXPATHLEN], disknum[MAXPATHLEN] = "0";
@@ -1359,9 +1363,9 @@ static long CALLBACK ISOopen(void) {
 	if (parsetoc(GetIsoFile()) == 0) {
 		strcat(image_str, "[+toc]");
 	}
-	else if (parseccd(GetIsoFile()) == 0) {
-		strcat(image_str, "[+ccd]");
-	}
+//	else if (parseccd(GetIsoFile()) == 0) {
+//		strcat(image_str, "[+ccd]");
+//	}
 	else if (parsemds(GetIsoFile()) == 0) {
 		strcat(image_str, "[+mds]");
 	}
@@ -1387,9 +1391,9 @@ static long CALLBACK ISOopen(void) {
 	}
 #endif // USE_LIBCHDR
 
-	if (!subChanMixed && opensubfile(GetIsoFile()) == 0) {
-		strcat(image_str, "[+sub]");
-	}
+//	if (!subChanMixed && opensubfile(GetIsoFile()) == 0) {
+//		strcat(image_str, "[+sub]");
+//	}
 	if (opensbifile(GetIsoFile()) == 0) {
 		strcat(image_str, "[+sbi]");
 	}


### PR DESCRIPTION
Following the conversation in https://github.com/xjsxjs197/WiiSXRX_2022/issues/139, and also since @xjsxjs197 agreed with removing support for IMG, CCD, SUB files on WiiStation, i worked in the past months trying to disable code for load these files.

Now the emulator will only allow loading BIN+CUE, CHD, and PBP.

The size reduction is not big, but at least we had reduced the memory usage, i guess.