### PR TITLE
correct some strings in OpenGX settings

### DIFF
--- a/Gamecube/menu/SettingsFrame.cpp
+++ b/Gamecube/menu/SettingsFrame.cpp
@@ -303,7 +303,7 @@ static char GPU_PLUGIN_STRINGS[4][24] =
     { "GPU Plugin",
       "Old Soft",
       "New Soft",
-      "Open Gx"
+      "OpenGX"
       };
 
 struct ButtonInfo
@@ -401,7 +401,7 @@ struct ButtonInfo
 
 	{	NULL,	BTN_A_SEL,	GPU_PLUGIN_STRINGS[1],	215.0,	160.0,	140.0,	56.0,	 5,	 7,	 66, 65,Func_UseOldSoftGpu,		Func_ReturnFromSettingsFrame }, // GpuPlugin: Old Soft
 	{	NULL,	BTN_A_SEL,	GPU_PLUGIN_STRINGS[2],	365.0,	160.0,	130.0,	56.0,	 6,	 9,	 64, 66,Func_UseNewSoftGpu,		Func_ReturnFromSettingsFrame }, // GpuPlugin: New Soft
-	{	NULL,	BTN_A_SEL,	GPU_PLUGIN_STRINGS[3],	505.0,	160.0,	130.0,	56.0,	 6,	 9,	 65, 64,Func_UseOpenGxGpu,		Func_ReturnFromSettingsFrame }, // GpuPlugin: Open Gx
+	{	NULL,	BTN_A_SEL,	GPU_PLUGIN_STRINGS[3],	505.0,	160.0,	130.0,	56.0,	 6,	 9,	 65, 64,Func_UseOpenGxGpu,		Func_ReturnFromSettingsFrame }, // GpuPlugin: OpenGX
 };
 
 struct TextBoxInfo
@@ -444,7 +444,7 @@ struct TextBoxInfo
 	{	NULL,	FRAME_STRINGS[63],	405.0,	368.0,	 1.0,	true }, // Fast load
 	{	NULL,	FRAME_STRINGS[76],	150.0,	338.0,	 1.0,	true }, // Memcard enable
     //TextBoxes for Saves Tab (starts at textBox[24]) ..was[24]
-	{	NULL,	GPU_PLUGIN_STRINGS[0],	110.0,	188.0,	 1.0,	true }, // Gpu Plugin: Old Soft/New Soft/Open Gx
+	{	NULL,	GPU_PLUGIN_STRINGS[0],	110.0,	188.0,	 1.0,	true }, // GPU Plugin: Old Soft/New Soft/OpenGX
 };
 
 SettingsFrame::SettingsFrame()


### PR DESCRIPTION
It's been a while since last time i contributed to WiiStation, and i've seen lots of progress with the OpenGX GPU plugin, but i've found a small mistake in the strings.
Let's just correct that.